### PR TITLE
Update class organization for enums, models, and type aliases

### DIFF
--- a/demo/src/main/kotlin/dev/teogor/sudoklify/demo/Main.kt
+++ b/demo/src/main/kotlin/dev/teogor/sudoklify/demo/Main.kt
@@ -16,10 +16,10 @@
 
 package dev.teogor.sudoklify.demo
 
-import dev.teogor.sudoklify.Difficulty
-import dev.teogor.sudoklify.Sudoku
 import dev.teogor.sudoklify.SudokuGenerator
-import dev.teogor.sudoklify.Type
+import dev.teogor.sudoklify.model.Difficulty
+import dev.teogor.sudoklify.model.Sudoku
+import dev.teogor.sudoklify.model.Type
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/Seeds.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/Seeds.kt
@@ -1,5 +1,9 @@
 package dev.teogor.sudoklify
 
+import dev.teogor.sudoklify.model.Difficulty
+import dev.teogor.sudoklify.model.Sudoku
+import dev.teogor.sudoklify.model.Type
+
 val SEEDS: Array<Sudoku> = arrayOf(
   // 4x4, digits from 1 to 4
   Sudoku(

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/SudokuGenerator.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/SudokuGenerator.kt
@@ -16,47 +16,16 @@
 
 package dev.teogor.sudoklify
 
+import dev.teogor.sudoklify.types.Board
+import dev.teogor.sudoklify.model.Difficulty
+import dev.teogor.sudoklify.types.Layout
+import dev.teogor.sudoklify.model.Sudoku
+import dev.teogor.sudoklify.types.SudokuString
+import dev.teogor.sudoklify.types.Token
+import dev.teogor.sudoklify.types.TokenMap
+import dev.teogor.sudoklify.model.Type
 import kotlin.math.sqrt
 import kotlin.random.Random
-
-typealias Cell = String
-typealias SudokuString = String
-typealias PuzzleString = SudokuString
-typealias SolutionString = SudokuString
-typealias Token = String
-typealias Board = Array<Array<Cell>>
-typealias Layout = Array<IntArray>
-typealias TokenMap = Map<Token, Cell>
-
-enum class Type(val rows: Int, val cols: Int) {
-  TWO_BY_TWO(2, 2),
-  TWO_BY_THREE(2, 3),
-  TWO_BY_FOUR(2, 4),
-  THREE_BY_THREE(3, 3),
-  TWO_BY_FIVE(2, 5),
-  THREE_BY_FOUR(3, 4),
-  THREE_BY_FIVE(3, 5),
-  FOUR_BY_FOUR(4, 4),
-  FIVE_BY_FIVE(5, 5),
-  SIX_BY_SIX(6, 6),
-  SEVEN_BY_SEVEN(7, 7),
-  EIGHT_BY_EIGHT(8, 8),
-  NINE_BY_NINE(9, 9),
-}
-
-enum class Difficulty {
-  EASY,
-  MEDIUM,
-  HARD,
-  EXPERT,
-}
-
-data class Sudoku(
-  val puzzle: PuzzleString,
-  val solution: SolutionString,
-  val difficulty: Difficulty,
-  val type: Type,
-)
 
 class SudokuGenerator private constructor(
   private val random: Random,

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/model/Difficulty.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/model/Difficulty.kt
@@ -1,0 +1,8 @@
+package dev.teogor.sudoklify.model
+
+enum class Difficulty {
+  EASY,
+  MEDIUM,
+  HARD,
+  EXPERT,
+}

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/model/Sudoku.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/model/Sudoku.kt
@@ -1,0 +1,12 @@
+package dev.teogor.sudoklify.model
+
+import dev.teogor.sudoklify.types.PuzzleString
+import dev.teogor.sudoklify.types.SolutionString
+
+
+data class Sudoku(
+  val puzzle: PuzzleString,
+  val solution: SolutionString,
+  val difficulty: Difficulty,
+  val type: Type,
+)

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/model/Type.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/model/Type.kt
@@ -1,0 +1,17 @@
+package dev.teogor.sudoklify.model
+
+enum class Type(val rows: Int, val cols: Int) {
+  TWO_BY_TWO(2, 2),
+  TWO_BY_THREE(2, 3),
+  TWO_BY_FOUR(2, 4),
+  THREE_BY_THREE(3, 3),
+  TWO_BY_FIVE(2, 5),
+  THREE_BY_FOUR(3, 4),
+  THREE_BY_FIVE(3, 5),
+  FOUR_BY_FOUR(4, 4),
+  FIVE_BY_FIVE(5, 5),
+  SIX_BY_SIX(6, 6),
+  SEVEN_BY_SEVEN(7, 7),
+  EIGHT_BY_EIGHT(8, 8),
+  NINE_BY_NINE(9, 9),
+}

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/types/Board.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/types/Board.kt
@@ -1,0 +1,3 @@
+package dev.teogor.sudoklify.types
+
+typealias Board = Array<Array<Cell>>

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/types/Cell.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/types/Cell.kt
@@ -1,0 +1,3 @@
+package dev.teogor.sudoklify.types
+
+typealias Cell = String

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/types/Layout.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/types/Layout.kt
@@ -1,0 +1,3 @@
+package dev.teogor.sudoklify.types
+
+typealias Layout = Array<IntArray>

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/types/PuzzleString.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/types/PuzzleString.kt
@@ -1,0 +1,3 @@
+package dev.teogor.sudoklify.types
+
+typealias PuzzleString = SudokuString

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/types/SolutionString.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/types/SolutionString.kt
@@ -1,0 +1,3 @@
+package dev.teogor.sudoklify.types
+
+typealias SolutionString = SudokuString

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/types/SudokuString.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/types/SudokuString.kt
@@ -1,0 +1,3 @@
+package dev.teogor.sudoklify.types
+
+typealias SudokuString = String

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/types/Token.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/types/Token.kt
@@ -1,0 +1,3 @@
+package dev.teogor.sudoklify.types
+
+typealias Token = String

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/types/TokenMap.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/types/TokenMap.kt
@@ -1,0 +1,3 @@
+package dev.teogor.sudoklify.types
+
+typealias TokenMap = Map<Token, Cell>


### PR DESCRIPTION
**Changes Made:**

- Moved enums such as `Type` and `Difficulty` to the `dev.teogor.sudoklify.model` package to centralize the definition of different Sudoku types and difficulty levels.

- Restructured models like `Sudoku`, `Token`, `Cell`, `Layout`, and `TokenMap` into the `dev.teogor.sudoklify.model` package to enhance the separation between data structures and the main logic.

- Reorganized type aliases such as `SudokuString`, `PuzzleString`, `SolutionString`, `Board`, and others under the `dev.teogor.sudoklify.model` package for improved code organization.

These changes enhance the overall structure of the codebase and promote a more modular and organized architecture. The refactoring also contributes to better code understanding and future maintenance.