### PR TITLE
Add Extension Functions for Board and SudokuString Conversion

### DIFF
--- a/demo/src/main/kotlin/dev/teogor/sudoklify/demo/Main.kt
+++ b/demo/src/main/kotlin/dev/teogor/sudoklify/demo/Main.kt
@@ -18,6 +18,7 @@ package dev.teogor.sudoklify.demo
 
 import dev.teogor.sudoklify.difficulty
 import dev.teogor.sudoklify.exntensions.generateSudoku
+import dev.teogor.sudoklify.exntensions.toSequenceString
 import dev.teogor.sudoklify.model.Difficulty
 import dev.teogor.sudoklify.model.Sudoku
 import dev.teogor.sudoklify.model.Type
@@ -67,8 +68,7 @@ fun main() = runBlocking {
       val sudoku = sudokuParams.generateSudoku()
       sudokus.add(sudoku)
       val solution = sudoku.solution
-      println(sudoku)
-      if (solution != sudokusResult[index]) {
+      if (solution.toSequenceString() != sudokusResult[index]) {
         println("test constraint failed for $type")
       } else {
         println("test constraint passed for $type")

--- a/demo/src/main/kotlin/dev/teogor/sudoklify/demo/Main.kt
+++ b/demo/src/main/kotlin/dev/teogor/sudoklify/demo/Main.kt
@@ -22,7 +22,7 @@ import dev.teogor.sudoklify.model.Difficulty
 import dev.teogor.sudoklify.model.Sudoku
 import dev.teogor.sudoklify.model.Type
 import dev.teogor.sudoklify.seed
-import dev.teogor.sudoklify.paramsBuilder
+import dev.teogor.sudoklify.sudokuParamsBuilder
 import dev.teogor.sudoklify.type
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -51,7 +51,7 @@ fun main() = runBlocking {
     // 16x16 = todo
     val seed = 0L
     sudokusSize.forEachIndexed { index, type ->
-      val sudokuParams = paramsBuilder {
+      val sudokuParams = sudokuParamsBuilder {
         seed {
           seed
         }
@@ -85,7 +85,7 @@ fun main() = runBlocking {
       for (range in ranges) {
         launch {
           repeat(parallelism) {
-            val sudokuParams = paramsBuilder {
+            val sudokuParams = sudokuParamsBuilder {
               seed {
                 System.currentTimeMillis()
               }

--- a/demo/src/main/kotlin/dev/teogor/sudoklify/demo/Main.kt
+++ b/demo/src/main/kotlin/dev/teogor/sudoklify/demo/Main.kt
@@ -17,12 +17,12 @@
 package dev.teogor.sudoklify.demo
 
 import dev.teogor.sudoklify.difficulty
-import dev.teogor.sudoklify.getSudoku
+import dev.teogor.sudoklify.exntensions.generateSudoku
 import dev.teogor.sudoklify.model.Difficulty
 import dev.teogor.sudoklify.model.Sudoku
 import dev.teogor.sudoklify.model.Type
 import dev.teogor.sudoklify.seed
-import dev.teogor.sudoklify.sudokuBuilder
+import dev.teogor.sudoklify.paramsBuilder
 import dev.teogor.sudoklify.type
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -51,7 +51,7 @@ fun main() = runBlocking {
     // 16x16 = todo
     val seed = 0L
     sudokusSize.forEachIndexed { index, type ->
-      val sudokuBuilder = sudokuBuilder {
+      val sudokuParams = paramsBuilder {
         seed {
           seed
         }
@@ -64,7 +64,7 @@ fun main() = runBlocking {
           Difficulty.EASY
         }
       }
-      val sudoku = sudokuBuilder.getSudoku()
+      val sudoku = sudokuParams.generateSudoku()
       sudokus.add(sudoku)
       val solution = sudoku.solution
       println(sudoku)
@@ -85,7 +85,7 @@ fun main() = runBlocking {
       for (range in ranges) {
         launch {
           repeat(parallelism) {
-            val sudokuBuilder = sudokuBuilder {
+            val sudokuParams = paramsBuilder {
               seed {
                 System.currentTimeMillis()
               }
@@ -98,7 +98,7 @@ fun main() = runBlocking {
                 Difficulty.EASY
               }
             }
-            val sudoku = sudokuBuilder.getSudoku()
+            val sudoku = sudokuParams.generateSudoku()
             println(sudoku.solution)
             sudokus.add(sudoku)
           }

--- a/demo/src/main/kotlin/dev/teogor/sudoklify/demo/Main.kt
+++ b/demo/src/main/kotlin/dev/teogor/sudoklify/demo/Main.kt
@@ -16,10 +16,14 @@
 
 package dev.teogor.sudoklify.demo
 
-import dev.teogor.sudoklify.SudokuGenerator
+import dev.teogor.sudoklify.difficulty
+import dev.teogor.sudoklify.getSudoku
 import dev.teogor.sudoklify.model.Difficulty
 import dev.teogor.sudoklify.model.Sudoku
 import dev.teogor.sudoklify.model.Type
+import dev.teogor.sudoklify.seed
+import dev.teogor.sudoklify.sudokuBuilder
+import dev.teogor.sudoklify.type
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -47,11 +51,20 @@ fun main() = runBlocking {
     // 16x16 = todo
     val seed = 0L
     sudokusSize.forEachIndexed { index, type ->
-      val sudoku = SudokuGenerator.getSudoku(
-        difficulty = Difficulty.EASY,
-        seed = seed,
-        type = type,
-      )
+      val sudokuBuilder = sudokuBuilder {
+        seed {
+          seed
+        }
+
+        type {
+          type
+        }
+
+        difficulty {
+          Difficulty.EASY
+        }
+      }
+      val sudoku = sudokuBuilder.getSudoku()
       sudokus.add(sudoku)
       val solution = sudoku.solution
       println(sudoku)
@@ -72,11 +85,20 @@ fun main() = runBlocking {
       for (range in ranges) {
         launch {
           repeat(parallelism) {
-            val sudoku = SudokuGenerator.getSudoku(
-              difficulty = Difficulty.EASY,
-              seed = System.currentTimeMillis(),
-              type = Type.THREE_BY_THREE,
-            )
+            val sudokuBuilder = sudokuBuilder {
+              seed {
+                System.currentTimeMillis()
+              }
+
+              type {
+                Type.THREE_BY_THREE
+              }
+
+              difficulty {
+                Difficulty.EASY
+              }
+            }
+            val sudoku = sudokuBuilder.getSudoku()
             println(sudoku.solution)
             sudokus.add(sudoku)
           }

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/Builder.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/Builder.kt
@@ -1,0 +1,72 @@
+package dev.teogor.sudoklify
+
+import dev.teogor.sudoklify.model.Difficulty
+import dev.teogor.sudoklify.model.Type
+import kotlin.random.Random
+
+/**
+ * A builder class for configuring and creating instances of [SudokuGenerator].
+ */
+class Builder {
+  private var difficulty: Difficulty = Difficulty.EASY
+  private var seed: Long = 0
+  private var type: Type = Type.THREE_BY_THREE
+
+  /**
+   * Set the difficulty level of the Sudoku puzzle.
+   * @param difficulty The difficulty level to set.
+   * @return This builder instance for chaining.
+   */
+  internal fun setDifficulty(difficulty: Difficulty) = apply { this.difficulty = difficulty }
+
+  /**
+   * Set the seed for generating random numbers.
+   * @param seed The seed to set.
+   * @return This builder instance for chaining.
+   */
+  internal fun setSeed(seed: Long) = apply { this.seed = seed }
+
+  /**
+   * Set the type of the Sudoku grid.
+   * @param type The type to set.
+   * @return This builder instance for chaining.
+   */
+  internal fun setType(type: Type) = apply { this.type = type }
+
+  /**
+   * Build and return a [SudokuGenerator] instance using the configured settings.
+   * @return A configured [SudokuGenerator] instance.
+   */
+  fun build() = SudokuGenerator(Random(seed), type, difficulty)
+}
+
+/**
+ * Create a [SudokuGenerator] using the provided configuration.
+ * @param block Lambda for configuring the builder.
+ * @return [SudokuGenerator] instance.
+ */
+inline fun sudokuBuilder(crossinline block: Builder.() -> Unit) = Builder().apply(block).build()
+
+/**
+ * Set the difficulty level of the Sudoku puzzle using a lambda.
+ * @param block Lambda providing the difficulty level.
+ */
+fun Builder.difficulty(block: () -> Difficulty) {
+  setDifficulty(block())
+}
+
+/**
+ * Set the seed for generating random numbers using a lambda.
+ * @param block Lambda providing the seed.
+ */
+fun Builder.seed(block: () -> Long) {
+  setSeed(block())
+}
+
+/**
+ * Set the type of the Sudoku grid using a lambda.
+ * @param block Lambda providing the type.
+ */
+fun Builder.type(block: () -> Type) {
+  setType(block())
+}

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/ParamsBuilder.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/ParamsBuilder.kt
@@ -1,13 +1,13 @@
 package dev.teogor.sudoklify
 
 import dev.teogor.sudoklify.model.Difficulty
+import dev.teogor.sudoklify.model.SudokuParams
 import dev.teogor.sudoklify.model.Type
-import kotlin.random.Random
 
 /**
  * A builder class for configuring and creating instances of [SudokuGenerator].
  */
-class Builder {
+class ParamsBuilder {
   private var difficulty: Difficulty = Difficulty.EASY
   private var seed: Long = 0
   private var type: Type = Type.THREE_BY_THREE
@@ -34,10 +34,16 @@ class Builder {
   internal fun setType(type: Type) = apply { this.type = type }
 
   /**
-   * Build and return a [SudokuGenerator] instance using the configured settings.
-   * @return A configured [SudokuGenerator] instance.
+   * Build and return a [SudokuParams] instance using the configured settings.
+   *
+   * @return A [SudokuParams] instance containing the configured difficulty, seed,
+   *  and type for generating Sudoku puzzles.
    */
-  fun build() = SudokuGenerator(Random(seed), type, difficulty)
+  fun build() = SudokuParams(
+    difficulty,
+    seed,
+    type,
+  )
 }
 
 /**
@@ -45,13 +51,13 @@ class Builder {
  * @param block Lambda for configuring the builder.
  * @return [SudokuGenerator] instance.
  */
-inline fun sudokuBuilder(crossinline block: Builder.() -> Unit) = Builder().apply(block).build()
+inline fun paramsBuilder(crossinline block: ParamsBuilder.() -> Unit) = ParamsBuilder().apply(block).build()
 
 /**
  * Set the difficulty level of the Sudoku puzzle using a lambda.
  * @param block Lambda providing the difficulty level.
  */
-fun Builder.difficulty(block: () -> Difficulty) {
+fun ParamsBuilder.difficulty(block: () -> Difficulty) {
   setDifficulty(block())
 }
 
@@ -59,7 +65,7 @@ fun Builder.difficulty(block: () -> Difficulty) {
  * Set the seed for generating random numbers using a lambda.
  * @param block Lambda providing the seed.
  */
-fun Builder.seed(block: () -> Long) {
+fun ParamsBuilder.seed(block: () -> Long) {
   setSeed(block())
 }
 
@@ -67,6 +73,6 @@ fun Builder.seed(block: () -> Long) {
  * Set the type of the Sudoku grid using a lambda.
  * @param block Lambda providing the type.
  */
-fun Builder.type(block: () -> Type) {
+fun ParamsBuilder.type(block: () -> Type) {
   setType(block())
 }

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/ParamsBuilder.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/ParamsBuilder.kt
@@ -51,7 +51,9 @@ class ParamsBuilder {
  * @param block Lambda for configuring the builder.
  * @return [SudokuGenerator] instance.
  */
-inline fun paramsBuilder(crossinline block: ParamsBuilder.() -> Unit) = ParamsBuilder().apply(block).build()
+inline fun sudokuParamsBuilder(
+  crossinline block: ParamsBuilder.() -> Unit,
+) = ParamsBuilder().apply(block).build()
 
 /**
  * Set the difficulty level of the Sudoku puzzle using a lambda.

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/Seeds.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/Seeds.kt
@@ -1,30 +1,30 @@
 package dev.teogor.sudoklify
 
 import dev.teogor.sudoklify.model.Difficulty
-import dev.teogor.sudoklify.model.Sudoku
+import dev.teogor.sudoklify.model.SudokuBlueprint
 import dev.teogor.sudoklify.model.Type
 
-val SEEDS: Array<Sudoku> = arrayOf(
+val SEEDS: Array<SudokuBlueprint> = arrayOf(
   // 4x4, digits from 1 to 4
-  Sudoku(
+  SudokuBlueprint(
     puzzle = "ABCD----CDAB----",
     solution = "ABCDDBACBCADCDAB",
     difficulty = Difficulty.EASY,
     type = Type.TWO_BY_TWO,
   ),
-  Sudoku(
+  SudokuBlueprint(
     puzzle = "BADC----CABD----",
     solution = "BACDADBCDBACCDAB",
     difficulty = Difficulty.MEDIUM,
     type = Type.TWO_BY_TWO,
   ),
-  Sudoku(
+  SudokuBlueprint(
     puzzle = "CDBA----ABCD----",
     solution = "CDBACDABABCDABCD",
     difficulty = Difficulty.HARD,
     type = Type.TWO_BY_TWO,
   ),
-  Sudoku(
+  SudokuBlueprint(
     puzzle = "DCBA----BADC----",
     solution = "DCBAADCBBADCABCD",
     difficulty = Difficulty.EXPERT,
@@ -32,25 +32,25 @@ val SEEDS: Array<Sudoku> = arrayOf(
   ),
 
   // 9x9, digits from 1 to 9
-  Sudoku(
+  SudokuBlueprint(
     puzzle = "G--D--CAF---G----II-F--HG-BB-IAEDHGC--AFCG--D-G-B-----F-D--ABC---B------C--H-BFIA",
     solution = "GBHDIECAFACEGBFDHIIDFCAHGEBBFIAEDHGCEHAFCGIBDDGCBHIAFEFIDEGABCHHABIFCEDGCEGHDBFIA",
     difficulty = Difficulty.EASY,
     type = Type.THREE_BY_THREE,
   ),
-  Sudoku(
+  SudokuBlueprint(
     puzzle = "G-HEDCF---I-F--A--E--A-----C--I-DEH-I-------G--G--E---A----F--C-CF-E-GI-B-------E",
     solution = "GAHEDCFBIDICFBGAEHEFBAIHCGDCBAIGDEHFIHEBFADCGFDGHCEIABAEIGHFBDCHCFDEBGIABGDCAIHFE",
     difficulty = Difficulty.MEDIUM,
     type = Type.THREE_BY_THREE,
   ),
-  Sudoku(
+  SudokuBlueprint(
     puzzle = "-------HG-----H-D-A-G---EI--CE--DG--DBF---------BFID--HG---F----D--H---C--A-EG---",
     solution = "BEDFIACHGFICEGHBDAAHGDBCEIFICEHADGFBDBFGCEIAHGAHBFIDCEHGBCDFAEIEDIAHBFGCCFAIEGHBD",
     difficulty = Difficulty.HARD,
     type = Type.THREE_BY_THREE,
   ),
-  Sudoku(
+  SudokuBlueprint(
     puzzle = "-BI-------C----E---------AF---EBA-----A-I-G------C--I----H-E--D-E------GC-B--F---",
     solution = "FBIAEGDHCACHDFBEGIEDGCHIBAFGICEBAFDHBHAFIDGCEDFEGCHAIBIAFHGECBDHEDBACIFGCGBIDFHEA",
     difficulty = Difficulty.EXPERT,
@@ -58,25 +58,25 @@ val SEEDS: Array<Sudoku> = arrayOf(
   ),
 
   // 16x16, digits from 1 to 16
-  Sudoku(
+  SudokuBlueprint(
     puzzle = "---C---Af--BAe-E-Ad-F--HE-AdAf-I-Aj--A--AeAAbAcB---AdEH-AfAaE-----FCAa-G-Ab-BIDAe--FAd-E--AaAb-----E----AbAa---------AdH-A-Af-D-AjG--F-A-AaAc-G---CH-Af------F-AE---C-AaI-G-C--AcAa-Aj-Ae-H-AfAd---------EI----A-----IAb--Aj-AfB--HFAfB-Aj-Ae-AbAcAa-----DAcAb-DEF---AjAeAdBH--H--E-Af-AcB-FC--Ab-F-Ad-CAj--I---G---",
     solution = "AaAcDCAjIAAfHAbBAeFEGAdGFAbBHEAaAdAfAcIDAjCAeAIAjAeAAbAcBGCFAdEHDAfAaEHAfAdAeDFCAaAGAjAbAcBIDAeAjAfFAdAcEABAaAbCGIHCEFGBHAbAaAeAfAcIAAdDAjBAdHAbACAfIDEAjGAeAaFAcAIAaAcDGAjAeAdCHFAfBEAbAeDBFAfAEHAbAdCAcAaIAjGAbCEIAcAaGAjFAeAHDAfAdBAjAfGHAdBAeFEIDAaAcAbACAdAAcAaIAbCDAjGAfBEAeHFAfBIAjGAeHAbAcAaEAAdFCDAcAbCDEFIAGAjAeAdBHAaAfHGAEAaAfAdAcBDFCIAjAbAeFAaAdAeCAjDBIHAbAfGAAcE",
     difficulty = Difficulty.EASY,
     type = Type.FOUR_BY_FOUR,
   ),
-  Sudoku(
+  SudokuBlueprint(
     puzzle = "-Ab---AjAa-----G-EFD--AcBAf----AdAe-----------Ab-H--CAeAf-G--Aa---I-Af--AH-B---B-----Aa-G--AAb--Ac--B-H-Ab-C-G-AdAeG-A-IAd----FH---AbC-HAAeF--E----AaDAcAj----I--FAfEAd-DA---AbF----AAj-Ae-AcGA-D-Ad-G-Ab-B--I--BE--H-Ac-----Ab---I-AbF--Aj-B---Aa--Ae-AcGAe--B-Aj-----------CD----FAbB--HAfH-D-----CE---Aj-",
     solution = "HAbAfAdAcAjAaAeCBAIGDEFDACAcBAfHFEGAdAeAjAbIAaEBAjIGAdAAbFHAaDCAeAfAcGAeFAaDECIAcAfAbAjAHAdBFAfAdBAjAcDCHAaAeGIEAAbAaDAcAjAfBEHAAbICFGAeAdAeGEAAbIAdAaAfAjDFHAcBCAbCIHAAeFGAdEAcBAfAjAaDAcAjHGAeAbIBAaFAfEAdCDAAdIAaAbFCAfEDAAjHAeBAcGAFDCAdAaGAjAbAeBAcEIHAfBEAeAfHAAcDGICAdAbAaFAjIAdAbFEHAjAcBDGAfAaACAeCAcGAeIFBAAjAdHAaDAfAbEAjAaAECDAeAfIAcFAbBAdGHAfHBDAaGAbAdAeCEAAcFAjI",
     difficulty = Difficulty.MEDIUM,
     type = Type.FOUR_BY_FOUR,
   ),
-  Sudoku(
+  SudokuBlueprint(
     puzzle = "I--AaF---AcE-A---Aj-------C--DAa-AbB-G----DAAb-AdAe-E-----H----AaC---Af-GAe---A------F-Aa--I-Ae-IC----Af-Ac--Aj-AjG----HIAb-AaB-F-EAa-----Aj---H--CA--AaA--Af---H-----AcF-G-HE-AcAaB----CA-E--Ae-B----AbI-Ad-Ad--B-Ab------H---AI-D---AfH----Ae-----Ad-AaI-AfAeAj----D-AfC-AjAc--D-------E---B-DAd---GA--Af",
     solution = "IAbAeAaFHGBAcEAfACAdDAjAfAAdFEIAeCAjGDAaAcAbBHGCAjAcAfDAAbBAdAeHEIAaFDBHEAdAjAcAaCIAbFAfAGAeBHDAAbAdAfEGCFAjAaAcAeIAbAeFICGAaAEAfAdAcDHAjBAjGAcCDAeHIAbAAaBAdFAfEAaAdEAfAcBAjFAeDHIGCAAbAeAaAAjIAfFGAdHCDBEAbAcFDGAbHEAdAcAaBIAfAeAjCACEAfHAeABAjFAcGAbIDAdAaAdAcIBAaAbCDAAjEAeHAfFGAIAaDGFEAfHAbBAdAjAeAcCAcFBAdAAaIHAfAeAjCAbGEDHAfCGAjAcAbAeDAaAEFBIAdEAjAbAeBCDAdIFAcGAAaHAf",
     difficulty = Difficulty.HARD,
     type = Type.FOUR_BY_FOUR,
   ),
-  Sudoku(
+  SudokuBlueprint(
     puzzle = "----Ad---Ae----AfDCAc--G-AAjF--CAd-AbH-C--BG--D--HAb--Ae--Ae-D-B--Af-Ac--Ad-A--Ab-D--Ae-----Aj-AfAjA-AeHAbIC---EAa-AdFAfDB--G-AaAjAd--AbAI----IAAfAdAj-Aa-D-Ae-BD-Ad-Af-H-ABAjCI----BAfE--AGD-Aa--HAbAdIH-AAj---EAeAbGAf-CAaG-C-----Ad--H-Ac--F-D--H-A--E-Ad-Aj--C--EAj--G--AfH--Ac-EG-AcF--HAjI-Ae--DBAcAj----Af---Ae----",
     solution = "AbAjHFAdIAaAcAeEBAGAfDCAcAfAaGAeAAjFIDCAdBAbHECAdABGEAfDAaFHAbAcIAeAjEAeIDAbBCHAfGAcAjFAdAaAAdFAbAaDAcBAeCHAIEAjGAfAjAAcAeHAbICBAfGEAaDAdFAfDBCFGEAaAjAdAeAcAbAIHHGEIAAfAdAjAbAaFDCAeAcBDAaAdAcAfAeHAbABAjCIEFGAeBAfEICAGDAcAaFAjHAbAdIHFAAjDAcAdEAeAbGAfBCAaGAbCAjBAaFEAdIAfHDAcAAeFIDAfAaHAeAAcCEBAdGAjAbAaCAeAbEAjDIGAAdAfHFBAcAEGAdAcFAbBHAjIAaAeCAfDBAcAjHCAdGAfFAbDAeAAaEI",
     difficulty = Difficulty.EXPERT,

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/SudokuGenerator.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/SudokuGenerator.kt
@@ -17,6 +17,8 @@
 package dev.teogor.sudoklify
 
 import dev.teogor.sudoklify.exntensions.sortRandom
+import dev.teogor.sudoklify.exntensions.toBoard
+import dev.teogor.sudoklify.exntensions.toSequenceString
 import dev.teogor.sudoklify.model.Difficulty
 import dev.teogor.sudoklify.model.Sudoku
 import dev.teogor.sudoklify.model.SudokuBlueprint
@@ -54,8 +56,8 @@ internal class SudokuGenerator internal constructor(
     val layout = getLayout(baseLayout)
     val tokenMap = getTokenMap()
 
-    val puzzle = getSequence(layout, boardToSequence(seed.puzzle), tokenMap)
-    val solution = getSequence(layout, boardToSequence(seed.solution), tokenMap)
+    val puzzle = getSequence(layout, seed.puzzle.toSequenceString(), tokenMap)
+    val solution = getSequence(layout, seed.solution.toSequenceString(), tokenMap)
 
     return Sudoku(puzzle, solution, seed.difficulty, type)
   }
@@ -69,10 +71,12 @@ internal class SudokuGenerator internal constructor(
     return grid
   }
 
+  @Deprecated(message = "toSequenceString")
   private fun boardToSequence(board: Board): SudokuString = board.joinToString("") {
     it.joinToString("")
   }
 
+  @Deprecated(message = "toBoard")
   private fun sequenceToBoard(sequence: SudokuString): Board {
     return sequence.chunked(boxDigits)
       .map { chunk -> chunk.map { it.toString() }.toTypedArray() }
@@ -133,8 +137,8 @@ internal class SudokuGenerator internal constructor(
   private fun getSeed(seeds: Array<SudokuBlueprint>, difficulty: Difficulty): Sudoku {
     val randomItem = getRandomItem(getSeedsByDifficulty(getSeedsBySize(seeds, boxDigits), difficulty))
     return Sudoku(
-      puzzle = sequenceToBoard(randomItem.puzzle),
-      solution = sequenceToBoard(randomItem.solution),
+      puzzle = randomItem.puzzle.toBoard(boxDigits),
+      solution = randomItem.solution.toBoard(boxDigits),
       difficulty = randomItem.difficulty,
       type = randomItem.type,
     )

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/SudokuGenerator.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/SudokuGenerator.kt
@@ -31,7 +31,7 @@ import dev.teogor.sudoklify.types.toToken
 import kotlin.math.sqrt
 import kotlin.random.Random
 
-class SudokuGenerator internal constructor(
+internal class SudokuGenerator internal constructor(
   private val random: Random,
   private val type: Type,
   private val difficulty: Difficulty,

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/SudokuGenerator.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/SudokuGenerator.kt
@@ -31,19 +31,13 @@ import dev.teogor.sudoklify.types.toToken
 import kotlin.math.sqrt
 import kotlin.random.Random
 
-class SudokuGenerator private constructor(
+fun SudokuGenerator.getSudoku() = composeSudokuPuzzle()
+
+class SudokuGenerator internal constructor(
   private val random: Random,
   private val type: Type,
+  private val difficulty: Difficulty,
 ) {
-  companion object {
-    fun getSudoku(difficulty: Difficulty, seed: Long, type: Type): Sudoku {
-      val sudokuGenerator = SudokuGenerator(
-        random = Random(seed),
-        type = type,
-      )
-      return sudokuGenerator.getSudoku(difficulty)
-    }
-  }
 
   private val boxDigits = type.rows * type.cols
   private val totalDigits = boxDigits * boxDigits
@@ -56,7 +50,7 @@ class SudokuGenerator private constructor(
     }
   }
 
-  private fun getSudoku(difficulty: Difficulty): Sudoku {
+  internal fun composeSudokuPuzzle(): Sudoku {
     val seed = getSeed(SEEDS, difficulty)
     val layout = getLayout(baseLayout)
     val tokenMap = getTokenMap()

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/SudokuGenerator.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/SudokuGenerator.kt
@@ -31,8 +31,6 @@ import dev.teogor.sudoklify.types.toToken
 import kotlin.math.sqrt
 import kotlin.random.Random
 
-fun SudokuGenerator.getSudoku() = composeSudokuPuzzle()
-
 class SudokuGenerator internal constructor(
   private val random: Random,
   private val type: Type,

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/exntensions/SudokuBoardExtensions.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/exntensions/SudokuBoardExtensions.kt
@@ -1,0 +1,17 @@
+package dev.teogor.sudoklify.exntensions
+
+import dev.teogor.sudoklify.types.Board
+import dev.teogor.sudoklify.types.SudokuString
+
+
+fun Board.toSequenceString(): SudokuString = joinToString("") {
+  it.joinToString("")
+}
+
+fun SudokuString.toBoard(
+  boxDigits: Int,
+): Board {
+  return chunked(boxDigits)
+    .map { chunk -> chunk.map { it.toString() }.toTypedArray() }
+    .toTypedArray()
+}

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/exntensions/SudokuParamsExtensions.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/exntensions/SudokuParamsExtensions.kt
@@ -1,0 +1,10 @@
+package dev.teogor.sudoklify.exntensions
+
+import dev.teogor.sudoklify.SudokuGenerator
+import dev.teogor.sudoklify.model.Sudoku
+import dev.teogor.sudoklify.model.SudokuParams
+import kotlin.random.Random
+
+fun SudokuParams.generateSudoku() : Sudoku {
+  return SudokuGenerator(Random(seed), type, difficulty).composeSudokuPuzzle()
+}

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/model/Sudoku.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/model/Sudoku.kt
@@ -1,12 +1,32 @@
 package dev.teogor.sudoklify.model
 
-import dev.teogor.sudoklify.types.PuzzleString
-import dev.teogor.sudoklify.types.SolutionString
-
+import dev.teogor.sudoklify.types.Board
 
 data class Sudoku(
-  val puzzle: PuzzleString,
-  val solution: SolutionString,
+  val puzzle: Board,
+  val solution: Board,
   val difficulty: Difficulty,
   val type: Type,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as Sudoku
+
+    if (!puzzle.contentDeepEquals(other.puzzle)) return false
+    if (!solution.contentDeepEquals(other.solution)) return false
+    if (difficulty != other.difficulty) return false
+    if (type != other.type) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = puzzle.contentDeepHashCode()
+    result = 31 * result + solution.contentDeepHashCode()
+    result = 31 * result + difficulty.hashCode()
+    result = 31 * result + type.hashCode()
+    return result
+  }
+}

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/model/SudokuBlueprint.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/model/SudokuBlueprint.kt
@@ -1,0 +1,19 @@
+package dev.teogor.sudoklify.model
+
+import dev.teogor.sudoklify.types.PuzzleString
+import dev.teogor.sudoklify.types.SolutionString
+
+/**
+ * Represents a blueprint for generating Sudoku puzzles.
+ *
+ * @property puzzle The puzzle layout as a [PuzzleString].
+ * @property solution The solution layout as a [SolutionString].
+ * @property difficulty The difficulty level of the Sudoku puzzle.
+ * @property type The type of the Sudoku grid.
+ */
+data class SudokuBlueprint(
+  val puzzle: PuzzleString,
+  val solution: SolutionString,
+  val difficulty: Difficulty,
+  val type: Type,
+)

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/model/SudokuParams.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/model/SudokuParams.kt
@@ -1,0 +1,14 @@
+package dev.teogor.sudoklify.model
+
+/**
+ * Data class representing parameters for configuring a Sudoku puzzle generator.
+ *
+ * @property difficulty The difficulty level of the Sudoku puzzle.
+ * @property seed The seed for generating random numbers.
+ * @property type The type of the Sudoku grid.
+ */
+data class SudokuParams(
+  val difficulty: Difficulty,
+  val seed: Long,
+  val type: Type,
+)


### PR DESCRIPTION
This pull request adds new extension functions to improve the conversion between `Board` and `SudokuString` types in the `dev.teogor.sudoklify.exntensions` package. These functions enhance the usability and readability of the codebase by providing easy-to-use conversion methods. The new functions are:

1. `toSequenceString()` - This extension function converts a `Board` object to a `SudokuString` representation, making it more convenient to work with.

2. `toBoard(boxDigits: Int)` - This extension function converts a `SudokuString` to a `Board` object using the specified `boxDigits` value.

These additions enhance the modularity and maintainability of the codebase by encapsulating conversion logic within extension functions.