### PR TITLE
Update Package Name from "exntensions" to "extensions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ val params = sudokuParamsBuilder {
 3. Generate the Sudoku puzzle using the `generateSudoku` extension function.
 
 ```kotlin
-import dev.teogor.sudoklify.exntensions.generateSudoku
+import dev.teogor.sudoklify.extensions.generateSudoku
 
 val generatedSudoku = sudokuParams.generateSudoku()
 ```

--- a/demo/src/main/kotlin/dev/teogor/sudoklify/demo/Main.kt
+++ b/demo/src/main/kotlin/dev/teogor/sudoklify/demo/Main.kt
@@ -17,8 +17,8 @@
 package dev.teogor.sudoklify.demo
 
 import dev.teogor.sudoklify.difficulty
-import dev.teogor.sudoklify.exntensions.generateSudoku
-import dev.teogor.sudoklify.exntensions.toSequenceString
+import dev.teogor.sudoklify.extensions.generateSudoku
+import dev.teogor.sudoklify.extensions.toSequenceString
 import dev.teogor.sudoklify.model.Difficulty
 import dev.teogor.sudoklify.model.Sudoku
 import dev.teogor.sudoklify.model.Type

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/SudokuGenerator.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/SudokuGenerator.kt
@@ -16,9 +16,9 @@
 
 package dev.teogor.sudoklify
 
-import dev.teogor.sudoklify.exntensions.sortRandom
-import dev.teogor.sudoklify.exntensions.toBoard
-import dev.teogor.sudoklify.exntensions.toSequenceString
+import dev.teogor.sudoklify.extensions.sortRandom
+import dev.teogor.sudoklify.extensions.toBoard
+import dev.teogor.sudoklify.extensions.toSequenceString
 import dev.teogor.sudoklify.model.Difficulty
 import dev.teogor.sudoklify.model.Sudoku
 import dev.teogor.sudoklify.model.SudokuBlueprint

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/extensions/RandomExtensions.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/extensions/RandomExtensions.kt
@@ -1,4 +1,4 @@
-package dev.teogor.sudoklify.exntensions
+package dev.teogor.sudoklify.extensions
 
 import kotlin.random.Random
 

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/extensions/SudokuBoardExtensions.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/extensions/SudokuBoardExtensions.kt
@@ -1,4 +1,4 @@
-package dev.teogor.sudoklify.exntensions
+package dev.teogor.sudoklify.extensions
 
 import dev.teogor.sudoklify.types.Board
 import dev.teogor.sudoklify.types.SudokuString

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/extensions/SudokuParamsExtensions.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/extensions/SudokuParamsExtensions.kt
@@ -1,4 +1,4 @@
-package dev.teogor.sudoklify.exntensions
+package dev.teogor.sudoklify.extensions
 
 import dev.teogor.sudoklify.SudokuGenerator
 import dev.teogor.sudoklify.model.Sudoku


### PR DESCRIPTION
This pull request addresses the package name typo in the codebase, correcting "exntensions" to "extensions" for improved consistency and clarity. This change ensures that the package name accurately reflects its purpose and aligns with the standard naming conventions.

Closes issue #15 .