### PR TITLE
Bump Maven Publish Version to 1.0.0-alpha02

### DIFF
--- a/sudoklify/build.gradle.kts
+++ b/sudoklify/build.gradle.kts
@@ -38,7 +38,7 @@ mavenPublishing {
 
   signAllPublications()
 
-  coordinates("dev.teogor.sudoklify", "sudoklify", "1.0.0-alpha01")
+  coordinates("dev.teogor.sudoklify", "sudoklify", "1.0.0-alpha02")
 
   pom {
     name.set("Sudoklify")


### PR DESCRIPTION
This PR updates the Maven publish version from 1.0.0-alpha01 to 1.0.0-alpha02 to reflect the latest changes and improvements. This version update ensures that users can access the most up-to-date features and enhancements provided by Sudoklify.