### PR TITLE
Enhance Difficulty Representation with Stars and Text Options

### DIFF
--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/utils/DifficultyExtensions.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/utils/DifficultyExtensions.kt
@@ -1,0 +1,25 @@
+package dev.teogor.sudoklify.utils
+
+import dev.teogor.sudoklify.model.Difficulty
+
+/**
+ * Converts the difficulty level to a string representation using stars.
+ *
+ * @return A string representation of the difficulty level using stars.
+ */
+fun Difficulty.toStars(): String {
+  return "★".repeat(ordinal + 1)
+}
+
+/**
+ * Converts the difficulty level to a string representation using the
+ * provided difficulty labels.
+ *
+ * @param labels An array of difficulty labels.
+ * 
+ * @return The corresponding difficulty label based on the ordinal position
+ * of the `Difficulty` enum value within the array.
+ */
+fun Difficulty.toLabel(labels: Array<String>): String {
+  return labels[ordinal]
+}


### PR DESCRIPTION
This pull request introduces new methods to represent difficulty levels using both stars and text labels.

### Changes

- Added a `toStars()` method to the `Difficulty` enum to convert a difficulty level to a string representation using stars.
- Added a `toLabel()` method to the `Difficulty` enum to convert a difficulty level to a string representation using the provided array of difficulty labels.

### Benefits

- These methods provide flexibility in displaying difficulty levels in different contexts and enhance the overall readability of the code.

### Code Examples

- Converting difficulty level to stars:

```kotlin
val difficulty = Difficulty.Medium
val starsRepresentation = difficulty.toStars()
println("Difficulty level in stars: $starsRepresentation")
```

- Converting difficulty level to text:

```kotlin
val difficultyLabels = arrayOf("Easy", "Medium", "Hard")
val difficulty = Difficulty.Medium
val textRepresentation = difficulty.toLabel(difficultyLabels)
println("Difficulty level in text: $textRepresentation")
```