### PR TITLE
Add `supportsDifficulty` function for GameType compatibility

### DIFF
--- a/sudoklify/api/sudoklify.api
+++ b/sudoklify/api/sudoklify.api
@@ -74,6 +74,10 @@ public final class dev/teogor/sudoklify/model/GameType : java/lang/Enum {
 	public static fun values ()[Ldev/teogor/sudoklify/model/GameType;
 }
 
+public final class dev/teogor/sudoklify/model/GameTypeKt {
+	public static final fun supportsDifficulty (Ldev/teogor/sudoklify/model/GameType;Ldev/teogor/sudoklify/model/Difficulty;)Z
+}
+
 public final class dev/teogor/sudoklify/model/Sudoku {
 	public fun <init> ([[Ljava/lang/String;[[Ljava/lang/String;Ldev/teogor/sudoklify/model/Difficulty;Ldev/teogor/sudoklify/model/GameType;)V
 	public final fun component1 ()[[Ljava/lang/String;

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/model/GameType.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/model/GameType.kt
@@ -16,6 +16,8 @@
 
 package dev.teogor.sudoklify.model
 
+import dev.teogor.sudoklify.SEEDS
+
 // TODO get box size and row/col size
 
 /**
@@ -122,3 +124,15 @@ enum class GameType(
     return "${cells}x$cells"
   }
 }
+
+/**
+ * Checks if this game type supports the specified difficulty level.
+ *
+ * @param difficulty The difficulty level to check for.
+ * @return True if the game type supports the given difficulty,
+ * false otherwise.
+ */
+fun GameType.supportsDifficulty(difficulty: Difficulty) =
+  SEEDS.any {
+    it.gameType == this && it.difficulty == difficulty
+  }


### PR DESCRIPTION
**Summary:**

This pull request introduces a new function named `supportsDifficulty` to the `GameType` enum. This function allows determining whether a specific `GameType` supports a given `Difficulty` level.

**Details:**

* The `supportsDifficulty` function takes a `Difficulty` as input and returns `true` if the current `GameType` supports it, and `false` otherwise.
* This functionality utilizes the `SEEDS` data source to determine compatible combinations.
* The implementation is efficient and leverages existing data structures.

**Benefits:**

* **Improved Developer Experience:** Enables clear checking of supported difficulties for each `GameType`.
* **Enhanced Code Readability:** Provides a dedicated function for this common task.
* **Reduced Errors:** Helps prevent invalid Difficulty assignments for unsupported `GameType`s.
* **Potential for Future Features:** Opens doors for Difficulty-based gameplay mechanics.
