### PR TITLE
Prepare for release `1.0.0-alpha04`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import com.diffplug.gradle.spotless.SpotlessPlugin
 import com.vanniktech.maven.publish.SonatypeHost
 import dev.teogor.winds.api.MavenPublish
 import dev.teogor.winds.api.getValue
+import dev.teogor.winds.api.model.DependencyType
 import dev.teogor.winds.api.model.Developer
 import dev.teogor.winds.api.model.LicenseType
 import dev.teogor.winds.api.model.createVersion
@@ -13,10 +14,10 @@ import org.jetbrains.dokka.gradle.DokkaPlugin
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.jetbrains.kotlin.jvm)
   alias(libs.plugins.winds)
   alias(libs.plugins.vanniktech.maven)
-  alias(libs.plugins.dokka)
+  alias(libs.plugins.jetbrains.dokka)
   alias(libs.plugins.spotless)
   alias(libs.plugins.api.validator)
 }
@@ -35,6 +36,7 @@ val excludedProjects = listOf(
 winds {
   buildFeatures {
     mavenPublish = true
+    docsGenerator = true
   }
 
   mavenPublish {
@@ -70,6 +72,11 @@ winds {
     addLicense(LicenseType.APACHE_2_0)
 
     addDeveloper(TeogorDeveloper())
+  }
+
+  docsGenerator {
+    name = "Sudoklify"
+    dependencyGatheringType = DependencyType.NONE
   }
 }
 

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -17,7 +17,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.jetbrains.kotlin.jvm)
   id("application")
 }
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -15,9 +15,9 @@ sizes and difficulty levels.
 
 ### Release
 
-|   Latest Update    | Stable Release | Beta Release | Alpha Release |
-|:------------------:|:--------------:|:------------:|:-------------:|
-| September 21, 2023 |       -        |      -       | 1.0.0-alpha03 |
+|   Latest Update   | Stable Release | Beta Release | Alpha Release |
+|:-----------------:|:--------------:|:------------:|:-------------:|
+| February 08, 2024 |       -        |      -       | 1.0.0-alpha04 |
 
 ### Declaring dependencies
 
@@ -30,7 +30,7 @@ Add the dependencies for the artifacts you need in the `build.gradle` file for y
 
     ```kotlin
     dependencies {
-      val sudoklify_version = "1.0.0-alpha03"
+      val sudoklify_version = "1.0.0-alpha04"
 
       implementation("dev.teogor.sudoklify:sudoklify:sudoklify_version")
     }
@@ -40,7 +40,7 @@ Add the dependencies for the artifacts you need in the `build.gradle` file for y
 
     ```groovy
     dependencies {
-      def sudoklify_version = "1.0.0-alpha03"
+      def sudoklify_version = "1.0.0-alpha04"
 
       implementation("dev.teogor.sudoklify:sudoklify:${sudoklify_version}")
     }
@@ -58,12 +58,54 @@ existing issue by clicking the star button.
 
 ### Version 1.0.0
 
+#### Version 1.0.0-alpha04
+
+February 08, 2024
+
+`dev.teogor.sudoklify:sudoklify-*:1.0.0-alpha04` is
+released. [Version 1.0.0-alpha04 contains these commits.](https://github.com/teogor/sudoklify/compare/1.0.0-alpha03...1.0.0-alpha04)
+
+**Enhancement**
+
+* Introduce more descriptive Cell type and board
+  serialization ([#40](https://github.com/teogor/sudoklify/pull/40))
+  by [@teogor](https://github.com/teogor)
+* Add `supportsDifficulty` function for GameType
+  compatibility ([#39](https://github.com/teogor/sudoklify/pull/39))
+  by [@teogor](https://github.com/teogor)
+* Enhance Sudoku seed generation for smaller puzzle
+  sizes ([#38](https://github.com/teogor/sudoklify/pull/38)) by [@teogor](https://github.com/teogor)
+* Implement Sudoku puzzle parsing and decoding ([#37](https://github.com/teogor/sudoklify/pull/37))
+  by [@teogor](https://github.com/teogor)
+* Enhance Sudoku Solver with Thorough Test
+  Suite ([#34](https://github.com/teogor/sudoklify/pull/34)) by [@teogor](https://github.com/teogor)
+* Enable Sudoku puzzle parsing and conversion with
+  SudokuParser ([#33](https://github.com/teogor/sudoklify/pull/33))
+  by [@teogor](https://github.com/teogor)
+* Enhance Sudoku Seeds with Additional Game Types and
+  Difficulties ([#32](https://github.com/teogor/sudoklify/pull/32))
+  by [@teogor](https://github.com/teogor)
+* Enhance Difficulty Representation with Stars and Text
+  Options ([#31](https://github.com/teogor/sudoklify/pull/31))
+  by [@teogor](https://github.com/teogor)
+* Refactor GameType enum for improved readability and
+  clarity ([30](https://github.com/teogor/sudoklify/pull/30))
+  by [@teogor](https://github.com/teogor)
+* Improve Difficulty Enum with Percentages and
+  Documentation ([#29](https://github.com/teogor/sudoklify/pull/29))
+  by [@teogor](https://github.com/teogor)
+
+**Bug Fixes**
+
+* Enhance Sudoku seed generation for smaller puzzle
+  sizes ([#38](https://github.com/teogor/sudoklify/pull/38)) by [@teogor](https://github.com/teogor)
+
 #### Version 1.0.0-alpha03
 
 September 21, 2023
 
 `dev.teogor.sudoklify:sudoklify-*:1.0.0-alpha03` is
-released. [Version 1.0.0-alpha02 contains these commits.](https://github.com/teogor/sudoklify/compare/1.0.0-alpha02...1.0.0-alpha03)
+released. [Version 1.0.0-alpha03 contains these commits.](https://github.com/teogor/sudoklify/compare/1.0.0-alpha02...1.0.0-alpha03)
 
 **Enhancement**
 

--- a/docs/releases/changelog/1.0.0-alpha04.md
+++ b/docs/releases/changelog/1.0.0-alpha04.md
@@ -1,0 +1,9 @@
+[//]: # (This file was automatically generated - do not edit)
+
+# Version 1.0.0-alpha04
+
+## Latest SDK versions
+
+| Status |            Service or Product             |       Gradle dependency        | Latest version |
+|:------:|:-----------------------------------------:|:------------------------------:|:--------------:|
+|   🧪   | [Sudoklify](../../../reference/sudoklify) | dev.teogor.sudoklify:sudoklify | 1.0.0-alpha04  |

--- a/docs/releases/implementation.md
+++ b/docs/releases/implementation.md
@@ -4,7 +4,7 @@
 
 ### Latest Version
 
-The latest release is [`1.0.0-alpha03`](../releases.md)
+The latest release is [`1.0.0-alpha04`](../releases.md)
 
 ### Releases
 
@@ -12,6 +12,7 @@ Here's a summary of the latest versions:
 
 |    Version    |               Release Notes                | Release Date |
 |:-------------:|:------------------------------------------:|:------------:|
+| 1.0.0-alpha04 | [changelog 🔗](changelog/1.0.0-alpha04.md) | 08 Feb 2024  |
 | 1.0.0-alpha03 | [changelog 🔗](changelog/1.0.0-alpha03.md) | 21 Sep 2023  |
 | 1.0.0-alpha02 | [changelog 🔗](changelog/1.0.0-alpha02.md) | 25 Aug 2023  |
 | 1.0.0-alpha01 | [changelog 🔗](changelog/1.0.0-alpha01.md) | 24 Aug 2023  |
@@ -27,7 +28,7 @@ libraries, in TOML format.
 
     ```toml title="gradle/libs.versions.toml"
     [versions]
-    sudoklify = "1.0.0-alpha03"
+    sudoklify = "1.0.0-alpha04"
 
     [libraries]
     sudoklify = { group = "dev.teogor.sudoklify", name = "sudoklify", version.ref = "sudoklify" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,8 +7,8 @@ kotlinx-coroutines = "1.7.3"
 kotlin-jvm = "1.9.22"
 vanniktech-maven = "0.27.0"
 spotless = "6.25.0"
-winds = "1.0.0-alpha04"
 junit = "5.10.1"
+winds = "1.0.0-beta01"
 
 [libraries]
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
@@ -18,8 +18,8 @@ junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.r
 
 [plugins]
 api-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "api-validator" }
-dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin-jvm" }
+jetbrains-dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin-jvm" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 vanniktech-maven = { id = "com.vanniktech.maven.publish", version.ref = "vanniktech-maven" }
 winds = { id = "dev.teogor.winds", version.ref = "winds" }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
     - releases.md
     - Implementation: releases/implementation.md
     - Changelog:
+      - 1.0.0-alpha04: releases/changelog/1.0.0-alpha04.md
       - 1.0.0-alpha03: releases/changelog/1.0.0-alpha03.md
       - 1.0.0-alpha02: releases/changelog/1.0.0-alpha02.md
       - 1.0.0-alpha01: releases/changelog/1.0.0-alpha01.md

--- a/sudoklify/build.gradle.kts
+++ b/sudoklify/build.gradle.kts
@@ -17,7 +17,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.jetbrains.kotlin.jvm)
   alias(libs.plugins.winds)
 }
 
@@ -44,5 +44,7 @@ winds {
   mavenPublish {
     displayName = "Sudoklify"
     name = "sudoklify"
+
+    // displayNameOverride = true
   }
 }


### PR DESCRIPTION
## Prepare for Upcoming 1.0.0-alpha04 Release

This pull request marks the next step towards the release of `1.0.0-alpha04`. It includes the following preparations:

- **Version Bump:** Updates the project version to `1.0.0-alpha04` in all relevant locations.
- **Changelog Updates:** Adds entries to the CHANGELOG file for features and changes introduced since the previous pre-release version.
- **Documentation Refresh:** Ensures documentation accurately reflects the upcoming release, including version information and potential breaking changes.

**Benefits:**

- Prepares the project for a stable and timely release of `1.0.0-alpha04`.
- Provides users with transparent information about changes and updates.
- Enables early feedback and testing for further development.