### PR TITLE
Ensure successful publishAllPublicationsToMavenCentral execution

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,4 +31,4 @@ jobs:
 
       - name: Publish to MavenCentral
         run: |
-          ./gradlew publishAllPublicationsToMavenCentral
+          ./gradlew publishAllPublicationsToMavenCentral --no-configuration-cache


### PR DESCRIPTION
**Summary:**

This pull request introduces a temporary workaround to ensure successful execution of `./gradlew publishAllPublicationsToMavenCentral` by adding the `--no-configuration-cache` flag.

**Background:**

There was an issue encountered when running `publishAllPublicationsToMavenCentral` due to potential conflicts with the Gradle configuration cache.

**Solution:**

This change adds the `--no-configuration-cache` flag to the command, temporarily bypassing the cache for this specific task. This allows the publishing process to complete successfully while we investigate the root cause of the cache-related issue.

**Benefits:**

* Enables reliable publishing of artifacts to Maven Central.
* Provides a temporary solution until a permanent fix can be implemented.

**Further Investigation:**

* We will continue to investigate the underlying cause of the configuration cache issue to find a more sustainable solution.
* We will monitor the publishing process closely to ensure stability.

**Additional Notes:**

* This is a temporary workaround and not intended as a long-term solution.
* Consider alternative solutions or potential updates to Gradle in the future.