### PR TITLE
Missing project URL in pom causing Sonatype service stop failure

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,9 +49,8 @@ winds {
       "Sudoklify stands as a versatile and user-friendly Sudoku puzzle generation library crafted in Kotlin. Effortlessly generate, manipulate, and solve Sudoku puzzles with ease."
 
     groupId = "dev.teogor.sudoklify"
-
+    url = "https://source.teogor.dev/sudoklify"
     artifactIdElements = 1
-
     inceptionYear = 2023
 
     sourceControlManagement(


### PR DESCRIPTION
**Summary:**

This pull request fixes an issue that prevented the Sonatype repository build service from stopping successfully. The problem stemmed from a missing project URL in the `sudoklify-1.0.0-alpha04.pom` file.

**Details:**

- Identified an error message: "Failed to stop service 'sonatype-repository-build-service'. Closing the repository failed with the following errors: Invalid POM: /dev/teogor/sudoklify/sudoklify/1.0.0-alpha04/sudoklify-1.0.0-alpha04.pom: Project URL missing".
- Traced the issue back to the missing project URL in the `$version.pom` file.
- This fix adds the missing project URL to the POM file, ensuring proper structure and compatibility with Sonatype service interactions.

**Benefits:**

- Enables successful stopping of the Sonatype repository build service.
- Maintains valid POM structure for future interactions and deployments.
- Prevents potential errors or inconsistencies during service management.

**Testing:**

- Manually verified that the Sonatype service can now be stopped successfully.
