### PR TITLE
Enhance `SudokuParams.createPuzzle()` by introducing `SudokuPuzzle` data class

### DIFF
--- a/demo/src/main/kotlin/dev/teogor/sudoklify/demo/gen/SudokuDecoder.kt
+++ b/demo/src/main/kotlin/dev/teogor/sudoklify/demo/gen/SudokuDecoder.kt
@@ -16,7 +16,7 @@
 
 package dev.teogor.sudoklify.demo.gen
 
-import dev.teogor.sudoklify.types.toToken
+import dev.teogor.sudoklify.utils.toToken
 import java.util.regex.Pattern
 
 class SudokuDecoder {

--- a/sudoklify/api/sudoklify.api
+++ b/sudoklify/api/sudoklify.api
@@ -23,6 +23,71 @@ public final class dev/teogor/sudoklify/SudokuParserKt {
 	public static final fun toSudokuIntArray (Ljava/lang/String;Ldev/teogor/sudoklify/model/GameType;)[[I
 }
 
+public final class dev/teogor/sudoklify/SudokuPuzzle {
+	public fun <init> (Ldev/teogor/sudoklify/model/Difficulty;Ldev/teogor/sudoklify/model/GameType;JLjava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ldev/teogor/sudoklify/model/Difficulty;Ldev/teogor/sudoklify/model/GameType;JLjava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/teogor/sudoklify/model/Difficulty;
+	public final fun component2 ()Ldev/teogor/sudoklify/model/GameType;
+	public final fun component3 ()J
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (Ldev/teogor/sudoklify/model/Difficulty;Ldev/teogor/sudoklify/model/GameType;JLjava/util/List;Ljava/util/List;Ljava/util/List;)Ldev/teogor/sudoklify/SudokuPuzzle;
+	public static synthetic fun copy$default (Ldev/teogor/sudoklify/SudokuPuzzle;Ldev/teogor/sudoklify/model/Difficulty;Ldev/teogor/sudoklify/model/GameType;JLjava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Ldev/teogor/sudoklify/SudokuPuzzle;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDifficulty ()Ldev/teogor/sudoklify/model/Difficulty;
+	public final fun getGameType ()Ldev/teogor/sudoklify/model/GameType;
+	public final fun getGivens ()Ljava/util/List;
+	public final fun getHints ()Ljava/util/List;
+	public final fun getSeed ()J
+	public final fun getSolution ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/teogor/sudoklify/SudokuPuzzle$Givens {
+	public fun <init> (III)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (III)Ldev/teogor/sudoklify/SudokuPuzzle$Givens;
+	public static synthetic fun copy$default (Ldev/teogor/sudoklify/SudokuPuzzle$Givens;IIIILjava/lang/Object;)Ldev/teogor/sudoklify/SudokuPuzzle$Givens;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCol ()I
+	public final fun getRow ()I
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/teogor/sudoklify/SudokuPuzzle$Hint {
+	public fun <init> (Ljava/lang/String;IILdev/teogor/sudoklify/SudokuPuzzle$HintType;)V
+	public synthetic fun <init> (Ljava/lang/String;IILdev/teogor/sudoklify/SudokuPuzzle$HintType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()Ldev/teogor/sudoklify/SudokuPuzzle$HintType;
+	public final fun copy (Ljava/lang/String;IILdev/teogor/sudoklify/SudokuPuzzle$HintType;)Ldev/teogor/sudoklify/SudokuPuzzle$Hint;
+	public static synthetic fun copy$default (Ldev/teogor/sudoklify/SudokuPuzzle$Hint;Ljava/lang/String;IILdev/teogor/sudoklify/SudokuPuzzle$HintType;ILjava/lang/Object;)Ldev/teogor/sudoklify/SudokuPuzzle$Hint;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCol ()I
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getRow ()I
+	public final fun getType ()Ldev/teogor/sudoklify/SudokuPuzzle$HintType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/teogor/sudoklify/SudokuPuzzle$HintType : java/lang/Enum {
+	public static final field BLOCK_ELIMINATION Ldev/teogor/sudoklify/SudokuPuzzle$HintType;
+	public static final field COL_ELIMINATION Ldev/teogor/sudoklify/SudokuPuzzle$HintType;
+	public static final field GUESS Ldev/teogor/sudoklify/SudokuPuzzle$HintType;
+	public static final field ROW_ELIMINATION Ldev/teogor/sudoklify/SudokuPuzzle$HintType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/teogor/sudoklify/SudokuPuzzle$HintType;
+	public static fun values ()[Ldev/teogor/sudoklify/SudokuPuzzle$HintType;
+}
+
 public final class dev/teogor/sudoklify/extensions/RandomExtensionsKt {
 	public static final fun getRandomItem (Lkotlin/random/Random;Ljava/util/List;)Ljava/lang/Object;
 	public static final fun sortRandom (Lkotlin/random/Random;)I
@@ -35,6 +100,7 @@ public final class dev/teogor/sudoklify/extensions/SudokuBoardExtensionsKt {
 }
 
 public final class dev/teogor/sudoklify/extensions/SudokuParamsExtensionsKt {
+	public static final fun createPuzzle (Ldev/teogor/sudoklify/model/SudokuParams;)Ldev/teogor/sudoklify/SudokuPuzzle;
 	public static final fun generateSudoku (Ldev/teogor/sudoklify/model/SudokuParams;)Ldev/teogor/sudoklify/model/Sudoku;
 }
 

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/SudokuPuzzle.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/SudokuPuzzle.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 Teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.sudoklify
+
+import dev.teogor.sudoklify.model.Difficulty
+import dev.teogor.sudoklify.model.GameType
+
+data class SudokuPuzzle(
+  val difficulty: Difficulty,
+  val gameType: GameType,
+  val seed: Long,
+  val givens: List<Givens>,
+  val solution: List<List<Int>>,
+  val hints: List<Hint> = emptyList(),
+) {
+  /**
+   * Data class for representing givens (fixed cells) in the puzzle.
+   */
+  data class Givens(
+    val row: Int,
+    val col: Int,
+    val value: Int,
+  )
+
+  /**
+   * Data class for representing hints (optional suggestions for solving).
+   */
+  data class Hint(
+    val message: String,
+    val row: Int,
+    val col: Int = -1,
+    val type: HintType,
+  )
+
+  enum class HintType {
+    ROW_ELIMINATION,
+    COL_ELIMINATION,
+    BLOCK_ELIMINATION,
+    GUESS,
+  }
+}

--- a/sudoklify/src/main/kotlin/dev/teogor/sudoklify/extensions/SudokuParamsExtensions.kt
+++ b/sudoklify/src/main/kotlin/dev/teogor/sudoklify/extensions/SudokuParamsExtensions.kt
@@ -17,8 +17,12 @@
 package dev.teogor.sudoklify.extensions
 
 import dev.teogor.sudoklify.SudokuGenerator
+import dev.teogor.sudoklify.SudokuPuzzle
+import dev.teogor.sudoklify.model.Difficulty
+import dev.teogor.sudoklify.model.GameType
 import dev.teogor.sudoklify.model.Sudoku
 import dev.teogor.sudoklify.model.SudokuParams
+import dev.teogor.sudoklify.types.Seed
 import kotlin.random.Random
 
 fun SudokuParams.generateSudoku(): Sudoku {
@@ -27,4 +31,28 @@ fun SudokuParams.generateSudoku(): Sudoku {
     gameType = gameType,
     difficulty = difficulty,
   ).composeSudokuPuzzle()
+}
+
+/**
+ * Generates a Sudoku puzzle with the specified parameters.
+ *
+ * This function creates a [SudokuPuzzle] object using the provided [SudokuParams].
+ * The created puzzle will have the specified difficulty level, seed, and game type.
+ *
+ * @receiver The `SudokuParams` object containing generation parameters.
+ * @return A `SudokuPuzzle` object representing the generated puzzle.
+ *
+ * @throws [IllegalArgumentException] if any of the parameters are invalid.
+ *
+ * @see Difficulty
+ * @see Seed
+ * @see GameType
+ * @see SudokuPuzzle
+ */
+fun SudokuParams.createPuzzle(): SudokuPuzzle {
+  return SudokuGenerator(
+    seed = seed,
+    gameType = gameType,
+    difficulty = difficulty,
+  ).createPuzzle()
 }

--- a/sudoklify/src/test/kotlin/dev/teogor/sudoklify/SudokuParamsTest.kt
+++ b/sudoklify/src/test/kotlin/dev/teogor/sudoklify/SudokuParamsTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 Teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.sudoklify
+
+import dev.teogor.sudoklify.extensions.createPuzzle
+import dev.teogor.sudoklify.model.Difficulty
+import dev.teogor.sudoklify.model.GameType
+import dev.teogor.sudoklify.model.SudokuParams
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class SudokuParamsTest {
+  @Test
+  fun createPuzzle_returnsPuzzleWithCorrectParams() {
+    val params = SudokuParams(
+        difficulty = Difficulty.EASY,
+        gameType = GameType.NineDigits,
+        seed = 1234L,
+    )
+
+    val puzzle = params.createPuzzle()
+
+    assertEquals(Difficulty.EASY, puzzle.difficulty)
+    assertEquals(GameType.NineDigits, puzzle.gameType)
+    assertEquals(1234L, puzzle.seed)
+  }
+
+  @Test
+  fun createPuzzle_generatesDifferentPuzzlesWithDifferentSeeds() {
+    val params1 = SudokuParams(
+        difficulty = Difficulty.EASY,
+        gameType = GameType.NineDigits,
+        seed = 1234L,
+    )
+    val params2 = SudokuParams(
+        difficulty = Difficulty.EASY,
+        gameType = GameType.NineDigits,
+        seed = 4321L,
+    )
+
+    val puzzle1 = params1.createPuzzle()
+    val puzzle2 = params2.createPuzzle()
+
+    assertNotEquals(puzzle1, puzzle2)
+  }
+}
+

--- a/sudoklify/src/test/kotlin/dev/teogor/sudoklify/SudokuTest.kt
+++ b/sudoklify/src/test/kotlin/dev/teogor/sudoklify/SudokuTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package dev.teogor.sudoklify
 
 import dev.teogor.sudoklify.extensions.generateSudoku


### PR DESCRIPTION
**Motivation:**

- Refactor the `SudokuParams.createPuzzle()` function to encapsulate the generated puzzle in a dedicated `SudokuPuzzle` data class.
- Improve code readability, maintainability, and ease of use by providing a structured container for puzzle data.

**Changes:**

- Introduced `SudokuPuzzle` data class to hold:
    - `difficulty`: The puzzle's difficulty level.
    - `gameType`: The type of Sudoku grid used (e.g., 9x9, 16x16).
    - `seed`: The seed used for generation.
    - `givens`: A list of fixed cells (givens) in the puzzle.
    - `solution`: The complete solved grid.
    - `hints`: Optional hints to aid in solving (could be added in future).
- Updated `SudokuParams.createPuzzle()` to return a `SudokuPuzzle` object.

**Benefits:**

- Enhanced code clarity and organization.
- Simplified access to individual puzzle components.
- Potential for adding additional attributes to the `SudokuPuzzle` as needed.
- Reduced coupling between generation and usage logic.

**Testing:**

- Unit tests have been updated to reflect the new structure and ensure consistent behavior.