### PR TITLE
Improved accuracy and reliability of BoardCell conversions with comprehensive testing

### DIFF
--- a/demo/src/main/kotlin/dev/teogor/sudoklify/demo/gen/SudokuDecoder.kt
+++ b/demo/src/main/kotlin/dev/teogor/sudoklify/demo/gen/SudokuDecoder.kt
@@ -16,7 +16,7 @@
 
 package dev.teogor.sudoklify.demo.gen
 
-import dev.teogor.sudoklify.ktx.toBoardCell
+import dev.teogor.sudoklify.ktx.toJEncodedCell
 import java.util.regex.Pattern
 
 class SudokuDecoder {
@@ -35,7 +35,7 @@ class SudokuDecoder {
         if (cellContent == "&nbsp;") {
           "-"
         } else {
-          cellContent.toInt().toBoardCell()
+          cellContent.toInt().toJEncodedCell()
         }
       puzzleBuilder.append(parsedNumber)
     }

--- a/docs/j-encoding-for-sudoku-cells.md
+++ b/docs/j-encoding-for-sudoku-cells.md
@@ -1,0 +1,65 @@
+# J-Encoding for Sudoku Cells
+
+This document explains the algorithm used for encoding and decoding cell values in a Sudoku board,
+ensuring a concise and human-readable representation.
+
+## Algorithm Overview
+
+The algorithm employs a base-10 encoding scheme with specific mappings for digits:
+
+- **Digits 1-9:** Represented by lowercase letters 'a' to 'i'.
+- **Digit 0:** Represented by the letter 'j'.
+
+**Key characteristics**
+
+- **Initial Letter Capitalization:** The first letter in the encoded string is capitalized to
+  enhance readability and differentiation.
+- **Zero Handling:** The value 0 is represented by a hyphen (-) for clarity and consistency.
+
+## Encoding Process
+
+1. **Convert to String:** The integer representing the cell value is transformed into a string of
+   digits.
+2. **Map Digits to Letters:** Each digit is replaced with its corresponding letter (a to i for 1 to
+   9, j for 0).
+3. **Capitalize First Letter:** The first letter in the string is capitalized.
+4. **Return Encoded String:** The resulting string is the encoded JEncodedCell representation.
+
+## Decoding Process
+
+1. **Map Letters to Digits:** Each letter in the encoded string is mapped back to its corresponding
+   digit (a to i to 1 to 9, j to 0).
+2. **Handle Capitalization:** If the first letter is uppercase, it's converted to lowercase before
+   mapping.
+3. **Combine Digits:** The mapped digits are joined to form an integer.
+4. **Return Decoded Integer:** The integer is the decoded cell value.
+
+## **Example**
+
+### **Encoding**
+
+- **Input:** Integer `230`
+- **Steps:**
+  1. Convert to string: `'2', '3', '0'`
+  2. Map digits: `'b', 'c', 'j'`
+  3. Uppercase first: `'B', 'c', 'j'`
+- **Output:** String `"Bcj"`
+
+### **Decoding**
+
+- **Input:** String `"Bcj"`
+- **Steps:**
+  1. Split into characters: `'B', 'c', 'j'`
+  2. Map letters: `2, 3, 0`
+  3. Join digits: `230`
+- **Output:** Integer `230`
+
+## Code Implementation
+
+The algorithm is implemented in Kotlin as extension functions for the `Int` and `JEncodedCell` types,
+as shown in the provided code snippet.
+
+## Motivation
+
+This algorithm aims to create a compact and human-friendly representation of cell values in Sudoku
+boards, enhancing readability and understanding for both developers and users.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
     - Overview: index.md
     - Seed: seed.md
     - Sudoku Type: sudoku-type.md
+    - J-Encoding For Sudoku Cells: j-encoding-for-sudoku-cells.md
   - Releases:
     - releases.md
     - Implementation: releases/implementation.md

--- a/sudoklify-common/src/main/kotlin/dev/teogor/sudoklify/common/types/JEncodedCell.kt
+++ b/sudoklify-common/src/main/kotlin/dev/teogor/sudoklify/common/types/JEncodedCell.kt
@@ -19,4 +19,4 @@ package dev.teogor.sudoklify.common.types
 /**
  * Typealias for representing a single cell value in a game board.
  */
-typealias BoardCell = String
+typealias JEncodedCell = String

--- a/sudoklify-common/src/main/kotlin/dev/teogor/sudoklify/common/types/TokenMap.kt
+++ b/sudoklify-common/src/main/kotlin/dev/teogor/sudoklify/common/types/TokenMap.kt
@@ -16,4 +16,4 @@
 
 package dev.teogor.sudoklify.common.types
 
-typealias TokenMap = Map<BoardCell, Cell>
+typealias TokenMap = Map<JEncodedCell, Cell>

--- a/sudoklify-core/src/main/kotlin/dev/teogor/sudoklify/core/generation/SudokuGenerator.kt
+++ b/sudoklify-core/src/main/kotlin/dev/teogor/sudoklify/core/generation/SudokuGenerator.kt
@@ -32,7 +32,7 @@ import dev.teogor.sudoklify.core.util.sortRandom
 import dev.teogor.sudoklify.core.util.toBoard
 import dev.teogor.sudoklify.core.util.toSequenceString
 import dev.teogor.sudoklify.ktx.createSeed
-import dev.teogor.sudoklify.ktx.toBoardCell
+import dev.teogor.sudoklify.ktx.toJEncodedCell
 import kotlin.math.sqrt
 import kotlin.random.Random
 
@@ -228,7 +228,7 @@ internal class SudokuGenerator internal constructor(
     val tokenList =
       gridList.withIndex().map { (index, _) ->
         val value = if (index < boxDigits) (index + 1) else (index - boxDigits + 1)
-        value.toBoardCell()
+        value.toJEncodedCell()
       }.shuffled(random)
 
     val tokenMap =

--- a/sudoklify-core/src/main/kotlin/dev/teogor/sudoklify/core/io/BoardSerialization.kt
+++ b/sudoklify-core/src/main/kotlin/dev/teogor/sudoklify/core/io/BoardSerialization.kt
@@ -18,7 +18,7 @@ package dev.teogor.sudoklify.core.io
 
 import dev.teogor.sudoklify.common.InternalSudoklifyApi
 import dev.teogor.sudoklify.common.types.TokenMap
-import dev.teogor.sudoklify.ktx.toBoardCell
+import dev.teogor.sudoklify.ktx.toJEncodedCell
 
 /**
  * Generates a mapping between token values and their corresponding
@@ -36,7 +36,7 @@ fun generateTokenMap(boxDigits: Int): TokenMap {
   val tokenList =
     gridList.withIndex().map { (index, _) ->
       val value = if (index < boxDigits) (index + 1) else (index - boxDigits + 1)
-      value.toBoardCell()
+      value.toJEncodedCell()
     }
 
   val tokenMap =

--- a/sudoklify-ktx/api/sudoklify-ktx.api
+++ b/sudoklify-ktx/api/sudoklify-ktx.api
@@ -1,6 +1,6 @@
 public final class dev/teogor/sudoklify/ktx/BoardCellExtensionsKt {
-	public static final fun toBoardCell (I)Ljava/lang/String;
 	public static final fun toInt (Ljava/lang/String;)I
+	public static final fun toJEncodedCell (I)Ljava/lang/String;
 }
 
 public final class dev/teogor/sudoklify/ktx/DifficultyExtensionsKt {

--- a/sudoklify-ktx/src/main/kotlin/dev/teogor/sudoklify/ktx/BoardCellExtensions.kt
+++ b/sudoklify-ktx/src/main/kotlin/dev/teogor/sudoklify/ktx/BoardCellExtensions.kt
@@ -16,23 +16,22 @@
 
 package dev.teogor.sudoklify.ktx
 
-import dev.teogor.sudoklify.common.types.BoardCell
+import dev.teogor.sudoklify.common.types.JEncodedCell
 
 /**
- * Converts an integer representing a Sudoku cell value to its corresponding string representation
- * as a [BoardCell].
+ * Converts an integer representing a Sudoku cell value to its J-Encoded string representation.
  *
  * @receiver The integer representing the Sudoku cell value.
- * @return The string representation of the cell as a [BoardCell], using a base-10 encoding with
- * letters 'a' to 'j' (where 'j' represents 0), and capitalizing the first letter.
+ * @return The [JEncodedCell] string representation of the cell, using letters 'a' to 'j'
+ * (where 'j' is used for 0), and capitalizing the first letter.
  *
  * Example:
  * ```kotlin
- * 5.toBoardCell() // Returns "E"
- * 10.toBoardCell() // Returns "Aj"
+ * 5.toJEncodedCell() // Returns "E"
+ * 10.toJEncodedCell() // Returns "Aj"
  * ```
  */
-fun Int.toBoardCell(): BoardCell {
+fun Int.toJEncodedCell(): JEncodedCell {
   return when {
     this == 0 -> "-"
 
@@ -60,11 +59,11 @@ fun Int.toBoardCell(): BoardCell {
 }
 
 /**
- * Converts a string representation of a Sudoku cell ([BoardCell], [String]) to its corresponding
- * integer value.
+ * Converts a string representation of a Sudoku cell ([JEncodedCell], [String]) to its
+ * corresponding integer value.
  *
  * @receiver The string representation of the Sudoku cell.
- * @return The integer value represented by the [BoardCell], using the base-10 encoding with
+ * @return The integer value represented by the [JEncodedCell], using the base-10 encoding with
  * letters 'a' to 'j' (where 'j' represents 0).
  *
  * Example:
@@ -73,7 +72,7 @@ fun Int.toBoardCell(): BoardCell {
  * "Aj".toInt() // Returns 10
  * ```
  */
-fun BoardCell.toInt(): Int {
+fun JEncodedCell.toInt(): Int {
   return when {
     this == "-" -> 0
 

--- a/sudoklify-ktx/src/main/kotlin/dev/teogor/sudoklify/ktx/BoardCellExtensions.kt
+++ b/sudoklify-ktx/src/main/kotlin/dev/teogor/sudoklify/ktx/BoardCellExtensions.kt
@@ -18,20 +18,38 @@ package dev.teogor.sudoklify.ktx
 
 import dev.teogor.sudoklify.common.types.BoardCell
 
+/**
+ * Converts an integer representing a Sudoku cell value to its corresponding string representation
+ * as a [BoardCell].
+ *
+ * @receiver The integer representing the Sudoku cell value.
+ * @return The string representation of the cell as a [BoardCell], using a base-10 encoding with
+ * letters 'a' to 'j' (where 'j' represents 0), and capitalizing the first letter.
+ *
+ * Example:
+ * ```kotlin
+ * 5.toBoardCell() // Returns "E"
+ * 10.toBoardCell() // Returns "Aj"
+ * ```
+ */
 fun Int.toBoardCell(): BoardCell {
   return when {
     this == 0 -> "-"
+
+    this in 1..9 -> ('a' + this - 1).uppercase()
 
     else -> {
       var valueCopy = this
       buildString {
         while (valueCopy > 0) {
-          val char =
-            when (val digit = (valueCopy % 10)) {
-              0 -> 'j'
-              else -> ('a' + digit - 1)
-            }
-          append(char)
+          val digit = valueCopy % 10
+          append(
+            if (digit != 0) {
+              ('a' + digit - 1)
+            } else {
+              'j'
+            },
+          )
           valueCopy /= 10
         }
         reverse()
@@ -41,6 +59,20 @@ fun Int.toBoardCell(): BoardCell {
   }
 }
 
+/**
+ * Converts a string representation of a Sudoku cell ([BoardCell], [String]) to its corresponding
+ * integer value.
+ *
+ * @receiver The string representation of the Sudoku cell.
+ * @return The integer value represented by the [BoardCell], using the base-10 encoding with
+ * letters 'a' to 'j' (where 'j' represents 0).
+ *
+ * Example:
+ * ```kotlin
+ * "E".toInt() // Returns 5
+ * "Aj".toInt() // Returns 10
+ * ```
+ */
 fun BoardCell.toInt(): Int {
   return when {
     this == "-" -> 0
@@ -48,6 +80,10 @@ fun BoardCell.toInt(): Int {
     else ->
       map { char ->
         when {
+          char == 'j' || char == 'J' -> {
+            0
+          }
+
           char.isUpperCase() -> {
             char - 'A' + 1
           }

--- a/sudoklify-ktx/src/main/kotlin/dev/teogor/sudoklify/ktx/SudokuBoardExtensions.kt
+++ b/sudoklify-ktx/src/main/kotlin/dev/teogor/sudoklify/ktx/SudokuBoardExtensions.kt
@@ -17,7 +17,7 @@
 package dev.teogor.sudoklify.ktx
 
 import dev.teogor.sudoklify.common.InternalSudoklifyApi
-import dev.teogor.sudoklify.common.types.BoardCell
+import dev.teogor.sudoklify.common.types.JEncodedCell
 import dev.teogor.sudoklify.common.types.SudokuType
 
 /**
@@ -26,12 +26,12 @@ import dev.teogor.sudoklify.common.types.SudokuType
  *
  * @receiver The two-dimensional list of integers representing the Sudoku board.
  * @return The string representation of the Sudoku board, where each cell is encoded as a
- * [BoardCell] using its default encoding.
+ * [JEncodedCell] using its default encoding.
  */
 fun List<List<Int>>.mapToSudokuString(): String {
   return flatMap { cells ->
     cells.map { cell ->
-      cell.toBoardCell()
+      cell.toJEncodedCell()
     }
   }.joinToString("")
 }
@@ -49,7 +49,7 @@ fun List<List<Int>>.mapToSudokuString(): String {
 inline fun <T> List<List<T>>.mapToSudokuString(crossinline valueMapper: T.() -> Int): String {
   return flatMap { cells ->
     cells.map { cell ->
-      valueMapper(cell).toBoardCell()
+      valueMapper(cell).toJEncodedCell()
     }
   }.joinToString("")
 }

--- a/sudoklify-ktx/src/test/kotlin/dev/teogor/sudoklify/ktx/BoardCellExtensionsTest.kt
+++ b/sudoklify-ktx/src/test/kotlin/dev/teogor/sudoklify/ktx/BoardCellExtensionsTest.kt
@@ -1,0 +1,36 @@
+package dev.teogor.sudoklify.ktx
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class BoardCellExtensionsTest {
+  @Test
+  fun testZeroToBoardCell() {
+    val cell = 0.toBoardCell()
+    assertEquals("-", cell)
+  }
+
+  @Test
+  fun testSingleDigitToBoardCell() {
+    assertEquals("E", 5.toBoardCell())
+    assertEquals(2, "B".toInt())
+  }
+
+  @Test
+  fun testDoubleDigitToBoardCell() {
+    assertEquals("Bc", 23.toBoardCell())
+    assertEquals(64, "Fd".toInt())
+  }
+
+  @Test
+  fun testTripleDigitToBoardCell() {
+    assertEquals("Gdc", 743.toBoardCell())
+    assertEquals(409, "Dji".toInt())
+  }
+
+  @Test
+  fun testDashToInt() {
+    val value = "-".toInt()
+    assertEquals(0, value)
+  }
+}

--- a/sudoklify-ktx/src/test/kotlin/dev/teogor/sudoklify/ktx/BoardCellExtensionsTest.kt
+++ b/sudoklify-ktx/src/test/kotlin/dev/teogor/sudoklify/ktx/BoardCellExtensionsTest.kt
@@ -6,25 +6,25 @@ import org.junit.jupiter.api.Test
 class BoardCellExtensionsTest {
   @Test
   fun testZeroToBoardCell() {
-    val cell = 0.toBoardCell()
+    val cell = 0.toJEncodedCell()
     assertEquals("-", cell)
   }
 
   @Test
   fun testSingleDigitToBoardCell() {
-    assertEquals("E", 5.toBoardCell())
+    assertEquals("E", 5.toJEncodedCell())
     assertEquals(2, "B".toInt())
   }
 
   @Test
   fun testDoubleDigitToBoardCell() {
-    assertEquals("Bc", 23.toBoardCell())
+    assertEquals("Bc", 23.toJEncodedCell())
     assertEquals(64, "Fd".toInt())
   }
 
   @Test
   fun testTripleDigitToBoardCell() {
-    assertEquals("Gdc", 743.toBoardCell())
+    assertEquals("Gdc", 743.toJEncodedCell())
     assertEquals(409, "Dji".toInt())
   }
 


### PR DESCRIPTION
This pull request addresses an issue with the `BoardCell` encoding and decoding functions where digits containing 0 were not handled correctly.

Specifically, the fix addresses:
    - `toInt()`: Ensures that the 'J' character is correctly decoded as 0.
    - `toBoardCell()`: Handles cases where the integer is composed of digits containing 0 (e.g., 10, 20, etc.).

Additionally, this PR introduces unit tests to verify the corrected behavior and ensure future changes maintain the expected functionality.

**Using the fixed functions:**

Once you've implemented the fixes in `toBoardCell()` and `toInt()`, you can use them directly in your code like this:

```kotlin
// Convert an integer to its BoardCell representation:
val cellValue = 20
val cellRepresentation = cellValue.toBoardCell() // Expected output: "Bj"

// Convert a BoardCell string back to an integer:
val cellString = "Aj"
val intValue = cellString.toInt() // Expected output: 10

// Check if an integer matches its BoardCell representation:
val number = 10
if (number == cellString.toInt()) {
  println("Number $number matches its BoardCell representation: $cellString")
}
```
