### PR TITLE
Enable User-Driven Sudoku Generation with Public SudokuGenerator

### DIFF
--- a/sudoklify-core/api/sudoklify-core.api
+++ b/sudoklify-core/api/sudoklify-core.api
@@ -11,6 +11,12 @@ public final class dev/teogor/sudoklify/core/generation/ParamsBuilderKt {
 	public static final fun sudokuType (Ldev/teogor/sudoklify/core/generation/ParamsBuilder;Lkotlin/jvm/functions/Function0;)V
 }
 
+public final class dev/teogor/sudoklify/core/generation/SudokuGenerator {
+	public fun <init> ([Ldev/teogor/sudoklify/common/model/SudokuBlueprint;Lkotlin/random/Random;Ldev/teogor/sudoklify/common/types/SudokuType;Ldev/teogor/sudoklify/common/types/Difficulty;)V
+	public final fun composeSudokuPuzzle ()Ldev/teogor/sudoklify/common/model/Sudoku;
+	public final fun createPuzzle ()Ldev/teogor/sudoklify/common/model/SudokuPuzzle;
+}
+
 public final class dev/teogor/sudoklify/core/generation/SudokuGeneratorKt {
 	public static final fun createPuzzle (Ldev/teogor/sudoklify/common/model/SudokuParams;)Ldev/teogor/sudoklify/common/model/SudokuPuzzle;
 	public static final fun generateSudoku (Ldev/teogor/sudoklify/common/model/SudokuParams;)Ldev/teogor/sudoklify/common/model/Sudoku;

--- a/sudoklify-core/src/main/kotlin/dev/teogor/sudoklify/core/generation/SudokuGenerator.kt
+++ b/sudoklify-core/src/main/kotlin/dev/teogor/sudoklify/core/generation/SudokuGenerator.kt
@@ -36,7 +36,7 @@ import dev.teogor.sudoklify.ktx.toJEncodedCell
 import kotlin.math.sqrt
 import kotlin.random.Random
 
-internal class SudokuGenerator internal constructor(
+class SudokuGenerator internal constructor(
   private val seeds: Array<SudokuBlueprint>,
   private val seed: Seed,
   private val sudokuType: SudokuType,
@@ -48,14 +48,13 @@ internal class SudokuGenerator internal constructor(
   private val tokenizer: Tokenizer = Tokenizer.create(boxDigits)
 
   @Deprecated(
-    message =
-    """
-    This constructor is deprecated. Use the primary constructor
-    `SudokuGenerator(seeds, seed, sudokuType, difficulty)` instead.
-    """,
+    message = """
+      |This constructor is deprecated. Use the primary constructor
+      |`SudokuGenerator(seeds, seed, sudokuType, difficulty)` instead.
+      |""",
     replaceWith = ReplaceWith("SudokuGenerator(seeds, seed, sudokuType, difficulty)"),
   )
-  internal constructor(
+  constructor(
     seeds: Array<SudokuBlueprint>,
     random: Random,
     sudokuType: SudokuType,
@@ -70,16 +69,16 @@ internal class SudokuGenerator internal constructor(
 
   @Deprecated(
     message =
-    """
-    The composeSudokuPuzzle() method is deprecated. To create a Sudoku puzzle, use the more
-    versatile and efficient createPuzzle() method, which returns a SudokuPuzzle object with
-    additional features and utility methods. For compatibility with existing code,
-    composeSudokuPuzzle() also returns a Sudoku object, but it's recommended to transition to
-    using the richer functionality of SudokuPuzzle.
+      """
+    |The composeSudokuPuzzle() method is deprecated. To create a Sudoku puzzle, use the more
+    |versatile and efficient createPuzzle() method, which returns a SudokuPuzzle object with
+    |additional features and utility methods. For compatibility with existing code,
+    |composeSudokuPuzzle() also returns a Sudoku object, but it's recommended to transition to
+    |using the richer functionality of SudokuPuzzle.
     """,
     replaceWith = ReplaceWith("createPuzzle()"),
   )
-  internal fun composeSudokuPuzzle(): Sudoku {
+  fun composeSudokuPuzzle(): Sudoku {
     val seed = getSeed(seeds, difficulty)
     val layout = getLayout(baseLayout)
     val tokenMap = getTokenMap()
@@ -90,7 +89,7 @@ internal class SudokuGenerator internal constructor(
     return Sudoku(puzzle, solution, seed.difficulty, sudokuType)
   }
 
-  internal fun createPuzzle(): SudokuPuzzle {
+  fun createPuzzle(): SudokuPuzzle {
     val seed = getSeed(seeds, difficulty)
     val layout = getLayout(baseLayout)
     val tokenMap = getTokenMap()


### PR DESCRIPTION
This pull request allows users to directly generate Sudoku puzzles using the `SudokuGenerator` class. Previously, the class was marked as `internal`, restricting its usage within the project's internals.

**Changes:**

- **Public `SudokuGenerator` Class:**
    - Modifies the `SudokuGenerator` class access modifier from `internal` to `public`.
    - This change enables users to create instances of `SudokuGenerator` and leverage its functionalities for puzzle generation.

**Benefits:**

- **Enhanced User Control:** Empowers users to generate Sudoku puzzles without relying on extensions.
- **Improved Flexibility:** Grants developers the freedom to utilize the `SudokuGenerator` class in their own custom implementations.
- **Increased Modularity:** Promotes better separation of concerns between puzzle generation logic and application-specific code.

**Example Usage:**

```kotlin
val difficulty = Difficulty.EASY
val puzzle = SudokuParams(seeds = emptyArray(), seed = Seed.RANDOM, sudokuType = SudokuType.STANDARD, difficulty = difficulty).createPuzzle()

println(puzzle) // Prints the generated Sudoku puzzle
```