### PR TITLE
Enhance SudokuPuzzle with Grid Generation from Given Cells

### DIFF
--- a/sudoklify-ktx/api/sudoklify-ktx.api
+++ b/sudoklify-ktx/api/sudoklify-ktx.api
@@ -26,6 +26,10 @@ public final class dev/teogor/sudoklify/ktx/SudokuBoardExtensionsKt {
 	public static final fun mapToSudokuString (Ljava/util/List;Lkotlin/jvm/functions/Function1;)Ljava/lang/String;
 }
 
+public final class dev/teogor/sudoklify/ktx/SudokuPuzzleExtensionsKt {
+	public static final fun generateGridWithGivens (Ldev/teogor/sudoklify/common/model/SudokuPuzzle;)Ljava/util/List;
+}
+
 public final class dev/teogor/sudoklify/ktx/SudokuTypeExtensionsKt {
 	public static final fun areCellsInSameBox (Ldev/teogor/sudoklify/common/types/SudokuType;II)Z
 	public static final fun areCellsInSameBox (Ldev/teogor/sudoklify/common/types/SudokuType;IIII)Z

--- a/sudoklify-ktx/src/main/kotlin/dev/teogor/sudoklify/ktx/SudokuPuzzleExtensions.kt
+++ b/sudoklify-ktx/src/main/kotlin/dev/teogor/sudoklify/ktx/SudokuPuzzleExtensions.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.sudoklify.ktx
+
+import dev.teogor.sudoklify.common.model.SudokuPuzzle
+
+/**
+ * Generates a grid based on the Sudoku puzzle with the given cells filled in.
+ *
+ * @return A list of lists representing the generated grid, where each inner list
+ * represents a row and each element in the inner list represents a cell value.
+ */
+fun SudokuPuzzle.generateGridWithGivens(): List<List<Int>> {
+  val gridSize = sudokuType.uniqueDigitsCount
+  val grid = MutableList(gridSize) { MutableList(gridSize) { 0 } }
+
+  // Map givens to the grid
+  for (given in givens) {
+    grid[given.row][given.col] = given.value
+  }
+
+  return grid.toList()
+}

--- a/sudoklify-seeds/build.gradle.kts
+++ b/sudoklify-seeds/build.gradle.kts
@@ -28,6 +28,7 @@ winds {
 
 dependencies {
   implementation(project(":sudoklify-core"))
+  implementation(project(":sudoklify-ktx"))
   testImplementation(libs.junit.jupiter)
 }
 

--- a/sudoklify-seeds/src/test/kotlin/dev/teogor/sudoklify/seeds/SudokuSeedsTest.kt
+++ b/sudoklify-seeds/src/test/kotlin/dev/teogor/sudoklify/seeds/SudokuSeedsTest.kt
@@ -17,21 +17,20 @@
 package dev.teogor.sudoklify.seeds
 
 import dev.teogor.sudoklify.common.model.SudokuBlueprint
-import dev.teogor.sudoklify.common.types.Board
+import dev.teogor.sudoklify.core.generation.createPuzzle
 import dev.teogor.sudoklify.core.generation.difficulty
-import dev.teogor.sudoklify.core.generation.generateSudoku
 import dev.teogor.sudoklify.core.generation.seed
 import dev.teogor.sudoklify.core.generation.seeds
 import dev.teogor.sudoklify.core.generation.sudokuParamsBuilder
 import dev.teogor.sudoklify.core.generation.sudokuType
 import dev.teogor.sudoklify.core.util.toBoard
-import dev.teogor.sudoklify.core.util.toSequenceString
 import dev.teogor.sudoklify.ktx.createSeed
+import dev.teogor.sudoklify.seeds.utils.comparePuzzles
+import dev.teogor.sudoklify.seeds.utils.toSequenceString
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
-
 
 class SudokuSeedsTest {
   @Test
@@ -62,7 +61,7 @@ class SudokuSeedsTest {
       sudokuType { blueprint.sudokuType }
       difficulty { blueprint.difficulty }
     }
-    val sudoku = sudokuParams.generateSudoku()
+    val sudoku = sudokuParams.createPuzzle()
 
     assertEquals(
       blueprint.sudokuType,
@@ -74,9 +73,10 @@ class SudokuSeedsTest {
       sudoku.difficulty,
       "Difficulty level mismatch",
     )
+
     assertEquals(
       blueprint.puzzle,
-      sudoku.puzzle.toSequenceString(),
+      toSequenceString(sudoku),
       "Puzzle generation error",
     )
     assertEquals(
@@ -84,24 +84,5 @@ class SudokuSeedsTest {
       sudoku.solution.toSequenceString(),
       "Solution generation error",
     )
-  }
-
-  private fun comparePuzzles(puzzle: Board, solution: Board): Boolean {
-    if (puzzle.size != solution.size || puzzle[0].size != solution[0].size) {
-      return false
-    }
-
-    for (row in puzzle.indices) {
-      for (col in 0..<puzzle[row].size) {
-        val puzzleValue = puzzle[row][col]
-        val solvedValue = solution[row][col]
-
-        if (puzzleValue != "-" && puzzleValue != solvedValue) {
-          return false
-        }
-      }
-    }
-
-    return true
   }
 }

--- a/sudoklify-seeds/src/test/kotlin/dev/teogor/sudoklify/seeds/utils/SudokuPuzzleUtils.kt
+++ b/sudoklify-seeds/src/test/kotlin/dev/teogor/sudoklify/seeds/utils/SudokuPuzzleUtils.kt
@@ -1,0 +1,42 @@
+package dev.teogor.sudoklify.seeds.utils
+
+import dev.teogor.sudoklify.common.model.SudokuPuzzle
+import dev.teogor.sudoklify.ktx.generateGridWithGivens
+
+fun List<List<Int>>.toSequenceString(): String {
+  return flatten().joinToString("")
+}
+
+fun toSequenceString(sudokuPuzzle: SudokuPuzzle): String {
+  return sudokuPuzzle.generateGridWithGivens().map {
+    it.map {
+      if (it == 0) {
+        "-"
+      } else {
+        it.toString()
+      }
+    }
+  }.flatten().joinToString(separator = "")
+}
+
+fun comparePuzzles(
+  puzzle: Array<Array<String>>,
+  solution: Array<Array<String>>,
+): Boolean {
+  if (puzzle.size != solution.size || puzzle[0].size != solution[0].size) {
+    return false
+  }
+
+  for (row in puzzle.indices) {
+    for (col in 0..<puzzle[row].size) {
+      val puzzleValue = puzzle[row][col]
+      val solvedValue = solution[row][col]
+
+      if (puzzleValue != "-" && puzzleValue != solvedValue) {
+        return false
+      }
+    }
+  }
+
+  return true
+}


### PR DESCRIPTION
## Introduce Grid Generation from Given Cells

This pull request enhances the `SudokuPuzzle` class with the capability to generate a grid containing pre-filled given cells:

**New Function:**

```kotlin
fun SudokuPuzzle.generateGridWithGivens(): List<List<Int>>
```

**Purpose:**

- Generates a grid representation of the Sudoku puzzle with the given cells filled in.
- Constructs a 2D list where each inner list represents a row and each element stores a cell value.
- Simplifies display or external manipulation of Sudoku puzzles with pre-filled values.

**Functionality:**

1. Retrieves the grid size based on the `sudokuType.uniqueDigitsCount`.
2. Initializes a mutable 2D list to hold the grid values, initially filled with zeros.
3. Iterates through the `givens` collection.
4. For each `given`, assigns its `value` to the corresponding grid cell using its `row` and `col` coordinates.
5. Returns the completed grid as a read-only list of lists.

**Benefits:**

- **Improved Flexibility:** Enables working with Sudoku puzzles in a grid-like format with given cells.
- **Simplified UI Display:** Facilitates visual representation of Sudoku puzzles with pre-filled values.
- **External Manipulation:** Supports processing or solving Sudoku puzzles with givens using grid-based logic.
