### PR TITLE
Enable Consistent Sudoku Symbol Representation with `convertToSudokuSymbol`

### DIFF
--- a/demo/src/main/kotlin/dev/teogor/sudoklify/demo/gen/impl/SudokuDecoderImpl.kt
+++ b/demo/src/main/kotlin/dev/teogor/sudoklify/demo/gen/impl/SudokuDecoderImpl.kt
@@ -16,7 +16,6 @@
 
 package dev.teogor.sudoklify.demo.gen.impl
 
-import dev.teogor.sudoklify.common.types.Board
 import dev.teogor.sudoklify.common.types.Difficulty
 import dev.teogor.sudoklify.common.types.SudokuType
 import dev.teogor.sudoklify.core.io.toSudokuIntArray
@@ -97,8 +96,8 @@ fun main() {
 }
 
 private fun comparePuzzles(
-  puzzle: Board,
-  solution: Board,
+  puzzle: Array<Array<String>>,
+  solution: Array<Array<String>>,
 ): Boolean {
   if (puzzle.size != solution.size || puzzle[0].size != solution[0].size) {
     return false

--- a/sudoklify-core/src/main/kotlin/dev/teogor/sudoklify/core/io/SudokuParser.kt
+++ b/sudoklify-core/src/main/kotlin/dev/teogor/sudoklify/core/io/SudokuParser.kt
@@ -19,7 +19,6 @@
 package dev.teogor.sudoklify.core.io
 
 import dev.teogor.sudoklify.common.InternalSudoklifyApi
-import dev.teogor.sudoklify.common.types.SudokuString
 import dev.teogor.sudoklify.common.types.SudokuType
 import dev.teogor.sudoklify.core.util.toBoard
 
@@ -74,7 +73,7 @@ class SudokuParser(
  *
  * @throws [IllegalArgumentException] if the provided Sudoku puzzle string is invalid.
  */
-fun SudokuString.toSudokuIntArray(sudokuType: SudokuType): Array<IntArray> {
+fun String.toSudokuIntArray(sudokuType: SudokuType): Array<IntArray> {
   val parser = SudokuParser(this, sudokuType)
   return parser.toIntArray()
 }

--- a/sudoklify-core/src/main/kotlin/dev/teogor/sudoklify/core/tokenizer/Tokenizer.kt
+++ b/sudoklify-core/src/main/kotlin/dev/teogor/sudoklify/core/tokenizer/Tokenizer.kt
@@ -16,7 +16,6 @@
 
 package dev.teogor.sudoklify.core.tokenizer
 
-import dev.teogor.sudoklify.common.types.Board
 import dev.teogor.sudoklify.common.types.Layout
 import dev.teogor.sudoklify.common.types.TokenMap
 
@@ -51,7 +50,7 @@ sealed class Tokenizer {
     layout: Layout,
     sequence: String,
     tokenMap: TokenMap,
-  ): Board
+  ): Array<Array<String>>
 
   companion object {
     /**
@@ -87,7 +86,7 @@ sealed class Tokenizer {
       layout: Layout,
       sequence: String,
       tokenMap: TokenMap,
-    ): Board {
+    ): Array<Array<String>> {
       with(replaceTokens(sequence, tokenMap)) {
         return layout.map { row ->
           row.map { cell ->
@@ -119,7 +118,7 @@ sealed class Tokenizer {
       layout: Layout,
       sequence: String,
       tokenMap: TokenMap,
-    ): Board {
+    ): Array<Array<String>> {
       val tokens = extractTokens(sequence, tokenMap)
       return layout.map { row ->
         row.map { cell ->

--- a/sudoklify-core/src/main/kotlin/dev/teogor/sudoklify/core/util/BoardConversions.kt
+++ b/sudoklify-core/src/main/kotlin/dev/teogor/sudoklify/core/util/BoardConversions.kt
@@ -16,8 +16,6 @@
 
 package dev.teogor.sudoklify.core.util
 
-import dev.teogor.sudoklify.common.types.Board
-import dev.teogor.sudoklify.common.types.SudokuString
 import dev.teogor.sudoklify.common.types.SudokuType
 
 /**
@@ -25,7 +23,7 @@ import dev.teogor.sudoklify.common.types.SudokuType
  *
  * @return A `SudokuString` representing the board.
  */
-fun Board.toSequenceString(): SudokuString =
+fun Array<Array<String>>.toSequenceString(): String =
   joinToString("") {
     it.joinToString("")
   }
@@ -40,7 +38,7 @@ fun Board.toSequenceString(): SudokuString =
  * @return A `Board` representing the Sudoku puzzle.
  */
 @Deprecated("Use the `toBoard(sudokuType: SudokuType)` function instead.")
-fun SudokuString.toBoard(boxDigits: Int): Board {
+fun String.toBoard(boxDigits: Int): Array<Array<String>> {
   return chunked(boxDigits)
     .map { chunk -> chunk.map { it.toString() }.toTypedArray() }
     .toTypedArray()
@@ -55,7 +53,7 @@ fun SudokuString.toBoard(boxDigits: Int): Board {
  *
  * @return A list of lists of strings representing the Sudoku puzzle.
  */
-fun SudokuString.toBoard(sudokuType: SudokuType): Board {
+fun String.toBoard(sudokuType: SudokuType): Array<Array<String>> {
   val regex = Regex("([A-I][a-z]+)|-|[A-I]")
   val matches = regex.findAll(this)
   val matchedTokens = ArrayList<String>()

--- a/sudoklify-core/src/main/kotlin/dev/teogor/sudoklify/core/util/GameTypeUtils.kt
+++ b/sudoklify-core/src/main/kotlin/dev/teogor/sudoklify/core/util/GameTypeUtils.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package dev.teogor.sudoklify.core.util
 
 import dev.teogor.sudoklify.common.types.GameType

--- a/sudoklify-ktx/api/sudoklify-ktx.api
+++ b/sudoklify-ktx/api/sudoklify-ktx.api
@@ -1,4 +1,5 @@
 public final class dev/teogor/sudoklify/ktx/BoardCellExtensionsKt {
+	public static final fun convertToSudokuSymbol (I)Ljava/lang/String;
 	public static final fun toInt (Ljava/lang/String;)I
 	public static final fun toJEncodedCell (I)Ljava/lang/String;
 }

--- a/sudoklify-ktx/src/main/kotlin/dev/teogor/sudoklify/ktx/BoardCellExtensions.kt
+++ b/sudoklify-ktx/src/main/kotlin/dev/teogor/sudoklify/ktx/BoardCellExtensions.kt
@@ -94,3 +94,12 @@ fun JEncodedCell.toInt(): Int {
       }.fold(0) { acc, digit -> acc * 10 + digit }
   }
 }
+
+/**
+ * Converts the integer to a Sudoku symbol or digit.
+ *
+ * @return The string representation of the integer in base 10, converted to uppercase.
+ */
+fun Int.convertToSudokuSymbol(): String {
+  return toString(10).uppercase()
+}

--- a/sudoklify-ktx/src/main/kotlin/dev/teogor/sudoklify/ktx/PuzzleStringExtensions.kt
+++ b/sudoklify-ktx/src/main/kotlin/dev/teogor/sudoklify/ktx/PuzzleStringExtensions.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package dev.teogor.sudoklify.ktx
 
 import dev.teogor.sudoklify.common.types.PuzzleString


### PR DESCRIPTION
## Consistent Sudoku Symbol Conversion

This pull request introduces the `convertToSudokuSymbol` function to ensure consistent representation of digits as Sudoku symbols.

**New Function:**

```kotlin
fun Int.convertToSudokuSymbol(): String {
  return toString(10).uppercase()
}
```

**Purpose:**

- Converts an integer representing a Sudoku digit to its corresponding symbol.
- Employs base 10 conversion for symbol generation.
- Returns the converted symbol as an uppercase string (e.g., "1" becomes "1", "10" becomes "10").

**Benefits:**

- **Consistency:** Ensures all digits are converted to the same format for proper Sudoku symbol representation.
- **Readability:** Enhances code readability by using a dedicated function for symbol conversion.
- **Reusability:** Provides a reusable function for consistent symbol generation throughout the project.

**Considerations:**

- This approach assumes a Sudoku grid with a maximum of 10 unique symbols (digits 0-9).
- If a different symbol set is required, the conversion logic can be modified within the function.

**Testing:**

- Thoroughly test the `convertToSudokuSymbol` function with various integer values.
- Verify that the generated symbols match the expected base 10 uppercase representation.
- Integrate the function into existing code sections that require digit-to-symbol conversion.

By introducing this function, we promote consistent and reusable conversion of digits to Sudoku symbols within the project, improving code maintainability and clarity.