### PR TITLE
Bump sudoklify version to 1.0.0-beta02 for Release

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,7 +91,7 @@ winds {
       group = "dev.teogor.sudoklify"
       name = "sudoklify"
       version = createVersion(1, 0, 0) {
-        betaRelease(1)
+        betaRelease(2)
       }
       nameFormat = NameFormat.FULL
       artifactIdFormat = ArtifactIdFormat.MODULE_NAME_ONLY

--- a/docs/assets/winds/sudoklify.json
+++ b/docs/assets/winds/sudoklify.json
@@ -55,5 +55,62 @@
         "date": 1708516800
       }
     ]
+  },
+  {
+    "module": "dev.teogor.sudoklify:sudoklify",
+    "version": {
+      "major": 1,
+      "minor": 0,
+      "patch": 0,
+      "flag": "Beta",
+      "versionQualifier": 2
+    },
+    "date": 1709527948,
+    "dependencies": [
+      {
+        "module": "dev.teogor.sudoklify:sudoklify-common",
+        "version": {
+          "major": 1,
+          "minor": 0,
+          "patch": 0,
+          "flag": "Beta",
+          "versionQualifier": 2
+        },
+        "date": 1709527948
+      },
+      {
+        "module": "dev.teogor.sudoklify:sudoklify-core",
+        "version": {
+          "major": 1,
+          "minor": 0,
+          "patch": 0,
+          "flag": "Beta",
+          "versionQualifier": 2
+        },
+        "date": 1709527948
+      },
+      {
+        "module": "dev.teogor.sudoklify:sudoklify-ktx",
+        "version": {
+          "major": 1,
+          "minor": 0,
+          "patch": 0,
+          "flag": "Beta",
+          "versionQualifier": 2
+        },
+        "date": 1709527948
+      },
+      {
+        "module": "dev.teogor.sudoklify:sudoklify-seeds",
+        "version": {
+          "major": 1,
+          "minor": 0,
+          "patch": 0,
+          "flag": "Beta",
+          "versionQualifier": 2
+        },
+        "date": 1709527948
+      }
+    ]
   }
 ]

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,7 +78,7 @@ To use Sudoklify in your app, add the following dependencies to your app's `buil
 
     ```groovy title="build.gradle"
     dependencies {
-        def teogorSudoklify = "1.0.0-beta01"
+        def teogorSudoklify = "1.0.0-beta02"
         
         implementation "dev.teogor.sudoklify:sudoklify-common:$teogorSudoklify"
         implementation "dev.teogor.sudoklify:sudoklify-core:$teogorSudoklify"
@@ -91,7 +91,7 @@ To use Sudoklify in your app, add the following dependencies to your app's `buil
 
     ```kotlin title="build.gradle.kts"
     dependencies {
-        val teogorSudoklify = "1.0.0-beta01"
+        val teogorSudoklify = "1.0.0-beta02"
         
         implementation("dev.teogor.sudoklify:sudoklify-common:$teogorSudoklify")
         implementation("dev.teogor.sudoklify:sudoklify-core:$teogorSudoklify")
@@ -113,7 +113,7 @@ First, define the dependencies in the `libs.versions.toml` file:
 
     ```toml title="gradle/libs.versions.toml"
     [versions]
-    teogor-sudoklify = "1.0.0-beta01"
+    teogor-sudoklify = "1.0.0-beta02"
     
     [libraries]
     teogor-sudoklify-common = { group = "dev.teogor.sudoklify", name = "sudoklify-common", version.ref = "teogor-sudoklify" }
@@ -126,7 +126,7 @@ First, define the dependencies in the `libs.versions.toml` file:
 
     ```toml title="gradle/libs.versions.toml"
     [versions]
-    teogor-sudoklify = "1.0.0-beta01"
+    teogor-sudoklify = "1.0.0-beta02"
     
     [libraries]
     teogor-sudoklify-common = { module = "dev.teogor.sudoklify:sudoklify-common", version.ref = "teogor-sudoklify" }

--- a/docs/releases/changelog/1.0.0-beta02.md
+++ b/docs/releases/changelog/1.0.0-beta02.md
@@ -1,0 +1,12 @@
+[//]: # (This file was automatically generated - do not edit)
+
+# Version 1.0.0-beta02
+
+## Latest SDK versions
+
+| Status |                 Service or Product                 |           Gradle dependency           | Latest version |
+|:------:|:--------------------------------------------------:|:-------------------------------------:|:--------------:|
+|  🛠️   | [Sudoklify Common](../../../html/sudoklify-common) | dev.teogor.sudoklify:sudoklify-common |  1.0.0-beta02  |
+|  🛠️   |   [Sudoklify Core](../../../html/sudoklify-core)   |  dev.teogor.sudoklify:sudoklify-core  |  1.0.0-beta02  |
+|  🛠️   |    [Sudoklify KTX](../../../html/sudoklify-ktx)    |  dev.teogor.sudoklify:sudoklify-ktx   |  1.0.0-beta02  |
+|  🛠️   |  [Sudoklify Seeds](../../../html/sudoklify-seeds)  | dev.teogor.sudoklify:sudoklify-seeds  |  1.0.0-beta02  |

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -21,9 +21,9 @@ API Reference
 
 [//]: # (REGION-RELEASE-TABLE)
 
-| Latest Update       |  Stable Release  |  Release Candidate  |  Beta Release  |  Alpha Release  |
-|:--------------------|:----------------:|:-------------------:|:--------------:|:---------------:|
-| February 21, 2024   |        -         |          -          |  1.0.0-beta01  |        -        |
+| Latest Update    |  Stable Release  |  Release Candidate  |  Beta Release  |  Alpha Release  |
+|:-----------------|:----------------:|:-------------------:|:--------------:|:---------------:|
+| March 04, 2024   |        -         |          -          |  1.0.0-beta02  |        -        |
 
 [//]: # (REGION-RELEASE-TABLE)
 
@@ -37,7 +37,7 @@ To use Sudoklify in your app, add the following dependencies to your app's `buil
 
     ```groovy title="build.gradle"
     dependencies {
-        def teogorSudoklify = "1.0.0-beta01"
+        def teogorSudoklify = "1.0.0-beta02"
         
         implementation "dev.teogor.sudoklify:sudoklify-common:$teogorSudoklify"
         implementation "dev.teogor.sudoklify:sudoklify-core:$teogorSudoklify"
@@ -50,7 +50,7 @@ To use Sudoklify in your app, add the following dependencies to your app's `buil
 
     ```kotlin title="build.gradle.kts"
     dependencies {
-        val teogorSudoklify = "1.0.0-beta01"
+        val teogorSudoklify = "1.0.0-beta02"
         
         implementation("dev.teogor.sudoklify:sudoklify-common:$teogorSudoklify")
         implementation("dev.teogor.sudoklify:sudoklify-core:$teogorSudoklify")
@@ -78,6 +78,28 @@ for this library before you create a new one.
 [//]: # (REGION-VERSION-CHANGELOG)
 
 ### Version 1.0.0
+
+#### Version 1.0.0-beta02
+
+March 04, 2024
+
+[`dev.teogor.sudoklify:sudoklify-*:1.0.0-beta02`](https://github.com/teogor/sudoklify/releases/1.0.0-beta02) is released. [Version 1.0.0-beta02 contains these commits](https://github.com/teogor/sudoklify/compare/1.0.0-beta01...1.0.0-beta02)
+
+**Enhancement**
+
+* Enable Consistent Sudoku Symbol Representation with `convertToSudokuSymbol` ([#63](https://github.com/teogor/sudoklify/issues/63)) by [@teogor](https://github.com/teogor)
+* Enhance SudokuPuzzle with Grid Generation from Given Cells ([#62](https://github.com/teogor/sudoklify/issues/62)) by [@teogor](https://github.com/teogor)
+* Enable User-Driven Sudoku Generation with Public SudokuGenerator ([#60](https://github.com/teogor/sudoklify/issues/60)) by [@teogor](https://github.com/teogor)
+* Improve Variable Naming for Clarity: uniqueDigitsCount & totalCells ([#59](https://github.com/teogor/sudoklify/issues/59)) by [@teogor](https://github.com/teogor)
+
+**Bug Fixes**
+
+* Ensure Compatibility During Deprecation: Replace Deprecated Functions in createPuzzle() ([#61](https://github.com/teogor/sudoklify/issues/61)) by [@teogor](https://github.com/teogor)
+* Improve Variable Naming for Clarity: uniqueDigitsCount & totalCells ([#59](https://github.com/teogor/sudoklify/issues/59)) by [@teogor](https://github.com/teogor)
+
+**Documentation**
+
+* Improve Documentation Clarity and User Guidance ([#64](https://github.com/teogor/sudoklify/issues/64)) by [@teogor](https://github.com/teogor)
 
 #### Version 1.0.0-beta01
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,9 +22,9 @@ nav:
     - Sudoku Type: sudoku-type.md
     - J-Encoding For Sudoku Cells: j-encoding-for-sudoku-cells.md
   - Releases:
-    - releases.md
-    - Implementation: releases/implementation.md
+    - releases/index.md
     - Changelog:
+      - 1.0.0-beta02: releases/changelog/1.0.0-beta02.md
       - 1.0.0-beta01: releases/changelog/1.0.0-beta01.md
       - 1.0.0-alpha04: releases/changelog/1.0.0-alpha04.md
       - 1.0.0-alpha03: releases/changelog/1.0.0-alpha03.md

--- a/winds-changelog.yml
+++ b/winds-changelog.yml
@@ -76,3 +76,16 @@
     - "Upgrade JVM Target Compatibility to Java 17 (Kotlin) (#56) by @teogor"
     - "Missing project URL in pom causing Sonatype service stop failure (#43) by @teogor"
     - "Ensure successful `publishAllPublicationsToMavenCentral` execution (#42) by @teogor"
+1.0.0-beta02:
+  info: "March 04, 2024"
+  sections:
+  - Enhancement:
+    - "Enable Consistent Sudoku Symbol Representation with `convertToSudokuSymbol` (#63) by @teogor"
+    - "Enhance SudokuPuzzle with Grid Generation from Given Cells (#62) by @teogor"
+    - "Enable User-Driven Sudoku Generation with Public SudokuGenerator (#60) by @teogor"
+    - "Improve Variable Naming for Clarity: uniqueDigitsCount & totalCells (#59) by @teogor"
+  - Bug Fixes:
+    - "Ensure Compatibility During Deprecation: Replace Deprecated Functions in createPuzzle() (#61) by @teogor"
+    - "Improve Variable Naming for Clarity: uniqueDigitsCount & totalCells (#59) by @teogor"
+  - Documentation:
+    - "Improve Documentation Clarity and User Guidance (#64) by @teogor"


### PR DESCRIPTION
## Changes

### - Enhancement

> Enable Consistent Sudoku Symbol Representation with `convertToSudokuSymbol` (#63) by @teogor
> Enhance SudokuPuzzle with Grid Generation from Given Cells (#62) by @teogor
> Enable User-Driven Sudoku Generation with Public SudokuGenerator (#60) by @teogor
> Improve Variable Naming for Clarity: `uniqueDigitsCount` \& `totalCells` (#59) by @teogor

### - Bug Fixes

> Ensure Compatibility During Deprecation: Replace Deprecated Functions in createPuzzle() (#61) by @teogor
> Improve Variable Naming for Clarity: `uniqueDigitsCount` \& `totalCells` (#59) by @teogor

### - Documentation

> Improve Documentation Clarity and User Guidance (#64) by @teogor

**Full Changelog**: https://github.com/teogor/sudoklify/compare/1.0.0-beta01...1.0.0-beta02